### PR TITLE
feat: support ticketing dashboard with live chat and department RBAC

### DIFF
--- a/admin/adminhome.html
+++ b/admin/adminhome.html
@@ -103,6 +103,7 @@
         ],
         accountsAdmin: [
           { href: 'account/index.html', text: 'Account Management' },
+          supportTicketsButton,
           shortLinkButton
         ],
         roomAdmin: [
@@ -128,6 +129,7 @@
         gateAdmin: [{ href: 'gate/index.html', text: 'Gate Management' }],
         adhyayanAdmin: [
           { href: 'adhyayan/index.html', text: 'Adhyayan Management' },
+          supportTicketsButton,
           shortLinkButton
         ],
         adhyayanAdminKol: [
@@ -183,7 +185,8 @@
           {
             href: 'maintenance/maintenance.html?department=electrical',
             text: 'Electrical Management'
-          }
+          },
+          supportTicketsButton
         ],
         adhyayanAdminReadOnly: [
           {
@@ -193,6 +196,7 @@
         ],
         utsavAdmin: [
           { href: 'utsav/index.html', text: 'Utsav Management' },
+          supportTicketsButton,
           shortLinkButton
         ],
         avtAdmin: [
@@ -204,6 +208,7 @@
         ],
         wifiAdmin: [
           { href: 'wifi/index.html', text: 'WiFi Management' },
+          supportTicketsButton,
           shortLinkButton
         ],
         smilesAdmin: [

--- a/admin/adminhome.html
+++ b/admin/adminhome.html
@@ -97,6 +97,7 @@
           { href: 'avt/index.html', text: 'AVT Management' },
           { href: 'wifi/index.html', text: 'WiFi Management' },
           { href: 'utsav/index.html', text: 'Utsav Management' },
+          { href: 'ticket/tickets.html', text: 'Support Tickets' },
           shortLinkButton
         ],
         accountsAdmin: [
@@ -164,7 +165,8 @@
           {
             href: 'maintenance/maintenance.html?department=maintenance',
             text: 'Maintenance Management'
-          }
+          },
+          { href: 'ticket/tickets.html', text: 'Support Tickets' }
         ],
         housekeepingAdmin: [
           {

--- a/admin/adminhome.html
+++ b/admin/adminhome.html
@@ -116,10 +116,12 @@
           { href: 'adhyayan/index.html', text: 'Adhyayan Management' },
           { href: 'card/index.html', text: 'Card Management' },
           { href: 'room/index.html', text: 'Room Management' },
+          { href: 'ticket/tickets.html', text: 'Support Tickets' },
           shortLinkButton
         ],
         foodAdmin: [
           { href: 'food/index.html', text: 'Food Management' },
+          { href: 'ticket/tickets.html', text: 'Support Tickets' },
           shortLinkButton
         ],
         gateAdmin: [{ href: 'gate/index.html', text: 'Gate Management' }],
@@ -153,6 +155,7 @@
         ],
         travelAdmin: [
           { href: 'travel/index.html', text: 'Travel Management' },
+          { href: 'ticket/tickets.html', text: 'Support Tickets' },
           shortLinkButton
         ],
         travelAdminDri: [
@@ -172,7 +175,8 @@
           {
             href: 'maintenance/maintenance.html?department=housekeeping',
             text: 'Housekeeping Management'
-          }
+          },
+          { href: 'ticket/tickets.html', text: 'Support Tickets' }
         ],
         electricalAdmin: [
           {

--- a/admin/adminhome.html
+++ b/admin/adminhome.html
@@ -81,6 +81,7 @@
         href: 'common/shortLinks.html',
         text: 'Short Link Management'
       };
+      const supportTicketsButton = { href: 'ticket/tickets.html', text: 'Support Tickets' };
 
       // Role-based button configuration
       const roleButtonMap = {
@@ -97,7 +98,7 @@
           { href: 'avt/index.html', text: 'AVT Management' },
           { href: 'wifi/index.html', text: 'WiFi Management' },
           { href: 'utsav/index.html', text: 'Utsav Management' },
-          { href: 'ticket/tickets.html', text: 'Support Tickets' },
+          supportTicketsButton,
           shortLinkButton
         ],
         accountsAdmin: [
@@ -116,12 +117,12 @@
           { href: 'adhyayan/index.html', text: 'Adhyayan Management' },
           { href: 'card/index.html', text: 'Card Management' },
           { href: 'room/index.html', text: 'Room Management' },
-          { href: 'ticket/tickets.html', text: 'Support Tickets' },
+          supportTicketsButton,
           shortLinkButton
         ],
         foodAdmin: [
           { href: 'food/index.html', text: 'Food Management' },
-          { href: 'ticket/tickets.html', text: 'Support Tickets' },
+          supportTicketsButton,
           shortLinkButton
         ],
         gateAdmin: [{ href: 'gate/index.html', text: 'Gate Management' }],
@@ -155,7 +156,7 @@
         ],
         travelAdmin: [
           { href: 'travel/index.html', text: 'Travel Management' },
-          { href: 'ticket/tickets.html', text: 'Support Tickets' },
+          supportTicketsButton,
           shortLinkButton
         ],
         travelAdminDri: [
@@ -169,14 +170,14 @@
             href: 'maintenance/maintenance.html?department=maintenance',
             text: 'Maintenance Management'
           },
-          { href: 'ticket/tickets.html', text: 'Support Tickets' }
+          supportTicketsButton
         ],
         housekeepingAdmin: [
           {
             href: 'maintenance/maintenance.html?department=housekeeping',
             text: 'Housekeeping Management'
           },
-          { href: 'ticket/tickets.html', text: 'Support Tickets' }
+          supportTicketsButton
         ],
         electricalAdmin: [
           {

--- a/admin/ticket/tickets.html
+++ b/admin/ticket/tickets.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script src="/style/js/roleCheck.js"></script>
+    <script>
+      checkRoleAccess(['superAdmin', 'maintenanceAdmin']); // customize allowed roles per page
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin | Support Tickets</title>
+
+    <!-- jQuery -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+
+    <!-- Additional Scripts -->
+    <script src="../../style/js/plugin.js"></script>
+    <script src="../../style/js/custom.js"></script>
+    <script src="../../sessionstorage.js"></script>
+    <script src="../../style/js/config.js"></script>
+    <script src="tickets.js" defer></script>
+
+    <!-- Shared Styles -->
+    <link rel="stylesheet" href="../../style/css/styles.css" />
+
+    <style>
+      .table-responsive {
+        width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      .table {
+        min-width: 900px;
+        width: 100%;
+      }
+
+      .filters {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+        margin-bottom: 1rem;
+      }
+
+      .filters select {
+        width: auto;
+      }
+
+      .unread-dot {
+        color: #d9534f;
+        font-weight: bold;
+        margin-right: 4px;
+      }
+
+      /* Drawer */
+      .drawer-overlay {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.35);
+        z-index: 998;
+      }
+
+      .drawer-overlay.open {
+        display: block;
+      }
+
+      .drawer {
+        position: fixed;
+        top: 0;
+        right: -520px;
+        width: 500px;
+        max-width: 92%;
+        height: 100%;
+        background: #fff;
+        box-shadow: -2px 0 8px rgba(0, 0, 0, 0.3);
+        transition: right 0.3s ease;
+        z-index: 999;
+        padding: 20px;
+        overflow-y: auto;
+      }
+
+      .drawer.open {
+        right: 0;
+      }
+
+      .drawer h3 {
+        color: #204060;
+      }
+
+      .ticket-meta p {
+        margin: 4px 0;
+      }
+
+      .messages {
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        padding: 10px;
+        max-height: 320px;
+        overflow-y: auto;
+        margin: 10px 0;
+        background: #fafafa;
+      }
+
+      .message {
+        margin-bottom: 10px;
+      }
+
+      .message.admin {
+        text-align: right;
+        color: #0066cc;
+      }
+
+      .message.user {
+        text-align: left;
+        color: #333;
+      }
+
+      .message p {
+        display: inline-block;
+        background: #eef2f7;
+        padding: 6px 10px;
+        border-radius: 8px;
+        max-width: 85%;
+        word-wrap: break-word;
+      }
+
+      .message.admin p {
+        background: #d7e8fc;
+      }
+
+      .message span {
+        display: block;
+        font-size: 11px;
+        color: #777;
+        margin-top: 2px;
+      }
+
+      #adminMessage {
+        width: 100%;
+        height: 70px;
+        padding: 8px;
+        border: 1px solid #ced4da;
+        border-radius: 4px;
+        resize: vertical;
+      }
+
+      .drawer-actions {
+        margin-top: 10px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .status-update {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+      }
+
+      /* Debug info panel */
+      .debug-panel {
+        margin-top: 16px;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+      }
+
+      .debug-panel-header {
+        background: #204060;
+        color: #fff;
+        padding: 8px 12px;
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-weight: 600;
+        border-radius: 4px 4px 0 0;
+      }
+
+      .debug-panel-body {
+        display: none;
+        padding: 10px 12px;
+      }
+
+      .debug-panel-body.open {
+        display: block;
+      }
+
+      .debug-kv-grid {
+        display: grid;
+        grid-template-columns: minmax(120px, 40%) 1fr;
+        gap: 4px 10px;
+        font-size: 13px;
+      }
+
+      .debug-kv-grid .debug-key {
+        font-weight: 600;
+        color: #204060;
+        word-break: break-word;
+      }
+
+      .debug-kv-grid .debug-value {
+        color: #333;
+        word-break: break-word;
+      }
+
+      .debug-raw-toggle {
+        margin-top: 10px;
+        display: inline-block;
+        cursor: pointer;
+        color: #4c86b0;
+        font-size: 12px;
+        text-decoration: underline;
+      }
+
+      .debug-raw-json {
+        display: none;
+        margin-top: 8px;
+        background: #1e1e1e;
+        color: #d4d4d4;
+        padding: 10px;
+        border-radius: 4px;
+        font-size: 12px;
+        max-height: 240px;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
+      .debug-raw-json.open {
+        display: block;
+      }
+
+      .debug-empty {
+        color: #777;
+        font-style: italic;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="header">
+      <div class="container">
+        <div class="logout">
+          <a href="javascript:void(0);" onclick="history.back()">Back</a>
+          &nbsp; | &nbsp;
+          <a href="javascript:void(0);" onclick="goToHome()">Home</a>
+          &nbsp; | &nbsp;
+          <a href="javascript:void(0);" onclick="logout()">Logout</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="middlecontent">
+      <div class="container">
+        <div class="whitesec">
+          <div class="inner-padding">
+            <div class="frm-head">
+              <h1>Support Tickets</h1>
+            </div>
+
+            <!-- Filters -->
+            <div class="filters">
+              <select id="statusFilter" class="form-control">
+                <option value="">All Status</option>
+                <option value="open">Open</option>
+                <option value="in progress">In Progress</option>
+                <option value="resolved">Resolved</option>
+                <option value="closed">Closed</option>
+              </select>
+
+              <select id="serviceFilter" class="form-control">
+                <option value="">All Services</option>
+                <option value="Maintenance">Maintenance</option>
+                <option value="IT Support">IT Support</option>
+                <option value="Housekeeping">Housekeeping</option>
+                <option value="Food">Food</option>
+                <option value="Travel">Travel</option>
+                <option value="Other">Other</option>
+              </select>
+
+              <button class="btn" onclick="fetchTickets()">Apply</button>
+            </div>
+
+            <!-- Tickets Table -->
+            <div class="table-responsive">
+              <table class="table" id="ticketTable">
+                <thead>
+                  <tr>
+                    <th>Ticket</th>
+                    <th>Issued By</th>
+                    <th>Service</th>
+                    <th>Status</th>
+                    <th>Created</th>
+                    <th>Last Message</th>
+                    <th>Action</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Drawer overlay + panel -->
+    <div class="drawer-overlay" id="drawerOverlay" onclick="closeDrawer()"></div>
+    <div class="drawer" id="ticketDrawer">
+      <h3 id="ticketTitle"></h3>
+      <div class="ticket-meta" id="ticketMeta"></div>
+
+      <hr />
+
+      <div class="messages" id="messageContainer"></div>
+
+      <textarea id="adminMessage" placeholder="Type your reply..."></textarea>
+
+      <div class="drawer-actions">
+        <div class="status-update">
+          <select id="statusUpdateSelect" class="form-control">
+            <option value="open">Open</option>
+            <option value="in progress">In Progress</option>
+            <option value="resolved">Resolved</option>
+            <option value="closed">Closed</option>
+          </select>
+          <button class="btn" onclick="updateStatus()">Update Status</button>
+        </div>
+        <div>
+          <button class="btn" onclick="sendReply()">Send</button>
+          <button class="btn" onclick="closeDrawer()">Close</button>
+        </div>
+      </div>
+
+      <!-- Debug info panel -->
+      <div class="debug-panel">
+        <div class="debug-panel-header" onclick="toggleDebugPanel()">
+          <span>Debug info</span>
+          <span id="debugPanelToggleIcon">&#9656;</span>
+        </div>
+        <div class="debug-panel-body" id="debugPanelBody">
+          <div id="debugKvGrid" class="debug-kv-grid"></div>
+          <span class="debug-raw-toggle" id="debugRawToggle" onclick="toggleDebugRaw()">Show raw JSON</span>
+          <pre class="debug-raw-json" id="debugRawJson"></pre>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/admin/ticket/tickets.html
+++ b/admin/ticket/tickets.html
@@ -343,8 +343,12 @@
             <option value="open">Open</option>
             <option value="in progress">In Progress</option>
             <option value="resolved">Resolved</option>
+            <!-- Display-only: admins can't set "closed" (backend rejects it),
+                 but the option must exist so a closed ticket's select shows the
+                 correct value instead of rendering blank. -->
+            <option value="closed" disabled>Closed</option>
           </select>
-          <button class="btn" onclick="updateStatus()">Update Status</button>
+          <button id="updateStatusBtn" class="btn" onclick="updateStatus()">Update Status</button>
         </div>
         <div>
           <button class="btn" onclick="sendReply()">Send</button>

--- a/admin/ticket/tickets.html
+++ b/admin/ticket/tickets.html
@@ -324,7 +324,6 @@
             <option value="open">Open</option>
             <option value="in progress">In Progress</option>
             <option value="resolved">Resolved</option>
-            <option value="closed">Closed</option>
           </select>
           <button class="btn" onclick="updateStatus()">Update Status</button>
         </div>

--- a/admin/ticket/tickets.html
+++ b/admin/ticket/tickets.html
@@ -3,7 +3,17 @@
   <head>
     <script src="/style/js/roleCheck.js"></script>
     <script>
-      checkRoleAccess(['superAdmin', 'maintenanceAdmin']); // customize allowed roles per page
+      // Department roles are scoped server-side to their own service — this
+      // list must stay in sync with TICKET_SERVICE_ROLE_MAP in the backend's
+      // config/constants.js.
+      checkRoleAccess([
+        'superAdmin',
+        'maintenanceAdmin',
+        'housekeepingAdmin',
+        'foodAdmin',
+        'travelAdmin',
+        'officeAdmin'
+      ]);
     </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/admin/ticket/tickets.html
+++ b/admin/ticket/tickets.html
@@ -254,6 +254,109 @@
         color: #777;
         font-style: italic;
       }
+
+      /* Media attachments */
+      .ticket-attachments {
+        margin: 8px 0;
+      }
+
+      .attachment-label {
+        font-size: 12px;
+        font-weight: 600;
+        color: #204060;
+        margin-bottom: 4px;
+      }
+
+      .attachment-strip {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 6px;
+      }
+
+      .attachment-thumb {
+        width: 90px;
+        height: 90px;
+        object-fit: cover;
+        border: 1px solid #ccd;
+        border-radius: 6px;
+        cursor: pointer;
+        background: #f0f0f0;
+      }
+
+      .attachment-expired {
+        font-size: 12px;
+        font-style: italic;
+        color: #999;
+      }
+
+      /* Compose-time preview strip for images picked but not yet sent */
+      .reply-preview-strip {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin: 6px 0;
+      }
+
+      .reply-preview-item {
+        position: relative;
+        width: 64px;
+        height: 64px;
+      }
+
+      .reply-preview-item img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border: 1px solid #ccd;
+        border-radius: 6px;
+      }
+
+      .reply-preview-remove {
+        position: absolute;
+        top: -6px;
+        right: -6px;
+        width: 18px;
+        height: 18px;
+        line-height: 16px;
+        text-align: center;
+        background: #d9534f;
+        color: #fff;
+        border-radius: 50%;
+        font-size: 13px;
+        cursor: pointer;
+        box-shadow: 0 0 2px rgba(0, 0, 0, 0.4);
+      }
+
+      /* Full-size media viewer */
+      .media-modal-overlay {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.8);
+        z-index: 1000;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .media-modal-overlay.open {
+        display: flex;
+      }
+
+      .media-modal-content {
+        max-width: 92%;
+        max-height: 92%;
+      }
+
+      .media-modal-media {
+        max-width: 90vw;
+        max-height: 90vh;
+        border-radius: 6px;
+        box-shadow: 0 0 20px rgba(0, 0, 0, 0.6);
+      }
     </style>
   </head>
 
@@ -342,11 +445,27 @@
       <h3 id="ticketTitle"></h3>
       <div class="ticket-meta" id="ticketMeta"></div>
 
+      <!-- Attachments filed with the original request (message_id === null) -->
+      <div class="ticket-attachments" id="ticketAttachments"></div>
+
       <hr />
 
       <div class="messages" id="messageContainer"></div>
 
       <textarea id="adminMessage" placeholder="Type your reply..."></textarea>
+
+      <!-- Thumbnails of images picked for the current reply, before sending -->
+      <div class="reply-preview-strip" id="replyPreviewStrip"></div>
+      <!-- Admins attach images only (video is user-only). Hidden input driven
+           by the "Attach Image" button below. -->
+      <input
+        type="file"
+        id="replyImageInput"
+        accept="image/*"
+        multiple
+        style="display: none"
+        onchange="onReplyFilesPicked(this)"
+      />
 
       <div class="drawer-actions">
         <div class="status-update">
@@ -362,7 +481,14 @@
           <button id="updateStatusBtn" class="btn" onclick="updateStatus()">Update Status</button>
         </div>
         <div>
-          <button class="btn" onclick="sendReply()">Send</button>
+          <button
+            class="btn"
+            type="button"
+            onclick="document.getElementById('replyImageInput').click()"
+          >
+            Attach Image
+          </button>
+          <button id="sendReplyBtn" class="btn" onclick="sendReply()">Send</button>
           <button class="btn" onclick="closeDrawer()">Close</button>
         </div>
       </div>
@@ -379,6 +505,17 @@
           <pre class="debug-raw-json" id="debugRawJson"></pre>
         </div>
       </div>
+    </div>
+
+    <!-- Full-size media viewer (opened when a thumbnail is clicked) -->
+    <div class="media-modal-overlay" id="mediaModalOverlay" onclick="closeMediaModal()">
+      <!-- stopPropagation so clicking the media (e.g. video controls) doesn't
+           close the modal; clicking the backdrop still does. -->
+      <div
+        class="media-modal-content"
+        id="mediaModalContent"
+        onclick="event.stopPropagation()"
+      ></div>
     </div>
   </body>
 </html>

--- a/admin/ticket/tickets.html
+++ b/admin/ticket/tickets.html
@@ -177,6 +177,74 @@
         align-items: center;
       }
 
+      /* Drawer header: title + close (X) */
+      .drawer-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 8px;
+      }
+      .drawer-header h3 {
+        margin: 0;
+        flex: 1;
+      }
+      .drawer-close-x {
+        background: none;
+        border: none;
+        font-size: 26px;
+        line-height: 1;
+        color: #999;
+        cursor: pointer;
+        padding: 0 4px;
+      }
+      .drawer-close-x:hover {
+        color: #333;
+      }
+
+      /* Compose / status action rows */
+      .status-label {
+        font-size: 12px;
+        color: #666;
+        margin-right: 4px;
+      }
+      .composer-actions {
+        display: flex;
+        gap: 8px;
+      }
+      .btn.btn-primary {
+        background: #204060;
+        color: #fff;
+        border: none;
+      }
+      .btn.btn-ghost {
+        background: #f1f3f5;
+        color: #333;
+        border: 1px solid #e0e3e7;
+      }
+      .btn.btn-secondary {
+        background: #e9ecef;
+        color: #333;
+        border: none;
+      }
+      .btn:disabled,
+      .btn[disabled] {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+      #adminMessage:disabled {
+        background: #f5f5f5;
+        color: #999;
+      }
+      .closed-note-composer {
+        margin-top: 8px;
+        padding: 8px;
+        background: #f5f5f5;
+        border-radius: 6px;
+        color: #777;
+        font-size: 12px;
+        text-align: center;
+      }
+
       /* Debug info panel */
       .debug-panel {
         margin-top: 16px;
@@ -459,7 +527,10 @@
     <!-- Drawer overlay + panel -->
     <div class="drawer-overlay" id="drawerOverlay" onclick="closeDrawer()"></div>
     <div class="drawer" id="ticketDrawer">
-      <h3 id="ticketTitle"></h3>
+      <div class="drawer-header">
+        <h3 id="ticketTitle"></h3>
+        <button class="drawer-close-x" onclick="closeDrawer()" aria-label="Close">&times;</button>
+      </div>
       <div class="ticket-meta" id="ticketMeta"></div>
 
       <!-- Attachments filed with the original request (message_id === null) -->
@@ -484,8 +555,13 @@
         onchange="onReplyFilesPicked(this)"
       />
 
+      <div id="closedNote" class="closed-note-composer" style="display: none">
+        This ticket is closed — no further replies can be sent.
+      </div>
+
       <div class="drawer-actions">
         <div class="status-update">
+          <span class="status-label">Status</span>
           <select id="statusUpdateSelect" class="form-control">
             <option value="open">Open</option>
             <option value="in progress">In Progress</option>
@@ -495,18 +571,20 @@
                  correct value instead of rendering blank. -->
             <option value="closed" disabled>Closed</option>
           </select>
-          <button id="updateStatusBtn" class="btn" onclick="updateStatus()">Update Status</button>
+          <button id="updateStatusBtn" class="btn btn-secondary" onclick="updateStatus()">
+            Update
+          </button>
         </div>
-        <div>
+        <div class="composer-actions">
           <button
-            class="btn"
+            id="attachImageBtn"
+            class="btn btn-ghost"
             type="button"
             onclick="document.getElementById('replyImageInput').click()"
           >
-            Attach Image
+            &#128206; Attach
           </button>
-          <button id="sendReplyBtn" class="btn" onclick="sendReply()">Send</button>
-          <button class="btn" onclick="closeDrawer()">Close</button>
+          <button id="sendReplyBtn" class="btn btn-primary" onclick="sendReply()">Send</button>
         </div>
       </div>
 

--- a/admin/ticket/tickets.html
+++ b/admin/ticket/tickets.html
@@ -25,6 +25,8 @@
     <!-- Additional Scripts -->
     <script src="../../sessionstorage.js"></script>
     <script src="../../style/js/config.js"></script>
+    <script src="../../style/js/htmlEscape.js"></script>
+    <script src="../../style/js/tableSortFilter.js" defer></script>
     <script src="tickets.js" defer></script>
 
     <!-- Shared Styles -->
@@ -292,6 +294,13 @@
               </select>
 
               <button class="btn" onclick="fetchTickets()">Apply</button>
+
+              <input
+                type="text"
+                id="ticketSearch"
+                class="form-control search-box"
+                placeholder="Search..."
+              />
             </div>
 
             <!-- Tickets Table -->

--- a/admin/ticket/tickets.html
+++ b/admin/ticket/tickets.html
@@ -4,15 +4,20 @@
     <script src="/style/js/roleCheck.js"></script>
     <script>
       // Department roles are scoped server-side to their own service — this
-      // list must stay in sync with TICKET_SERVICE_ROLE_MAP in the backend's
-      // config/constants.js.
+      // list must stay in sync with the roles in TICKET_SERVICE_ROLE_MAP in the
+      // backend's config/constants.js (every role that maps to a department).
       checkRoleAccess([
         'superAdmin',
-        'maintenanceAdmin',
+        'electricalAdmin',
         'housekeepingAdmin',
+        'maintenanceAdmin',
         'foodAdmin',
+        'adhyayanAdmin',
+        'officeAdmin',
         'travelAdmin',
-        'officeAdmin'
+        'utsavAdmin',
+        'wifiAdmin',
+        'accountsAdmin'
       ]);
     </script>
     <meta charset="UTF-8" />
@@ -285,12 +290,18 @@
 
               <select id="serviceFilter" class="form-control">
                 <option value="">All Services</option>
-                <option value="Maintenance">Maintenance</option>
-                <option value="IT Support">IT Support</option>
+                <option value="Electrical">Electrical</option>
                 <option value="Housekeeping">Housekeeping</option>
-                <option value="Food">Food</option>
-                <option value="Travel">Travel</option>
-                <option value="Other">Other</option>
+                <option value="Maintenance">Maintenance</option>
+                <option value="Raj Prasad">Raj Prasad</option>
+                <option value="Raj Adhyayan">Raj Adhyayan</option>
+                <option value="Raj Sharan">Raj Sharan</option>
+                <option value="Raj Pravas">Raj Pravas</option>
+                <option value="Raj Utsav">Raj Utsav</option>
+                <option value="WiFi">WiFi</option>
+                <option value="Payment/Accounts">Payment/Accounts</option>
+                <option value="IT">IT</option>
+                <option value="Others">Others</option>
               </select>
 
               <button class="btn" onclick="fetchTickets()">Apply</button>

--- a/admin/ticket/tickets.html
+++ b/admin/ticket/tickets.html
@@ -13,8 +13,6 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 
     <!-- Additional Scripts -->
-    <script src="../../style/js/plugin.js"></script>
-    <script src="../../style/js/custom.js"></script>
     <script src="../../sessionstorage.js"></script>
     <script src="../../style/js/config.js"></script>
     <script src="tickets.js" defer></script>

--- a/admin/ticket/tickets.html
+++ b/admin/ticket/tickets.html
@@ -290,6 +290,23 @@
         color: #999;
       }
 
+      /* Shown in place of a thumbnail whose authed media fetch failed. */
+      .attachment-error {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 90px;
+        height: 90px;
+        padding: 4px;
+        border: 1px dashed #d9534f;
+        border-radius: 6px;
+        background: #fdf3f3;
+        color: #d9534f;
+        font-size: 11px;
+        font-style: italic;
+        text-align: center;
+      }
+
       /* Compose-time preview strip for images picked but not yet sent */
       .reply-preview-strip {
         display: flex;

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -386,7 +386,7 @@ async function openTicket(ticketId) {
   ticketId = decodeURIComponent(ticketId);
 
   teardownStream(); // stop whatever ticket's stream was previously open
-  clearReplyFiles(); // drop any images composed for the previously-open ticket
+  resetComposer(); // drop the draft text + images composed for the previous ticket
   closeMediaModal(); // close any full-size media left open from the prior ticket
 
   currentTicketId = ticketId;
@@ -519,6 +519,21 @@ function populateDrawer(ticket) {
   statusSelect.disabled = isClosed;
   const updateStatusBtn = document.getElementById('updateStatusBtn');
   if (updateStatusBtn) updateStatusBtn.disabled = isClosed;
+
+  // A closed ticket is terminal — the backend rejects both status changes and
+  // new messages on it — so lock the whole composer and show a note instead of
+  // letting the admin type/attach/send a reply that would just 400.
+  const composerBox = document.getElementById('adminMessage');
+  const composerSend = document.getElementById('sendReplyBtn');
+  const composerAttach = document.getElementById('attachImageBtn');
+  const closedNote = document.getElementById('closedNote');
+  if (composerBox) {
+    composerBox.disabled = isClosed;
+    composerBox.placeholder = isClosed ? 'This ticket is closed.' : 'Type your reply...';
+  }
+  if (composerSend) composerSend.disabled = isClosed;
+  if (composerAttach) composerAttach.disabled = isClosed;
+  if (closedNote) closedNote.style.display = isClosed ? 'block' : 'none';
 
   const container = document.getElementById('messageContainer');
 
@@ -739,6 +754,15 @@ function clearReplyFiles() {
   if (strip) strip.innerHTML = '';
 }
 
+// Full composer reset — typed text AND staged images. Used when switching to a
+// different ticket or closing the drawer, so a draft never bleeds from one
+// ticket into another. (clearReplyFiles alone left the textarea text behind.)
+function resetComposer() {
+  const box = document.getElementById('adminMessage');
+  if (box) box.value = '';
+  clearReplyFiles();
+}
+
 // Presigns + PUTs each picked image directly to S3, returning the attachment
 // refs to send with the message. Order-matched: the presign response's Nth
 // { key, uploadUrl } corresponds to the Nth requested file.
@@ -900,7 +924,7 @@ function closeDrawer() {
   // Invalidate any authed-media fetch still in flight so it self-revokes on
   // resolve instead of leaking an object URL after the drawer is gone.
   renderGeneration++;
-  clearReplyFiles(); // drop any un-sent composed images
+  resetComposer(); // drop any un-sent draft text + composed images
   teardownStream();
   startTicketListRefresh(); // resume list polling
   currentTicketId = null;

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -3,6 +3,16 @@ let currentTicketId = null;
 let refreshInterval = null;
 let currentStreamAbort = null;
 let currentTicket = null;
+let streamReconnectTimer = null;
+let streamWatchdogTimer = null;
+let lastStreamActivity = 0;
+
+// A connection that's gone silently stale (a graceful close produces no
+// fetch error) is detected by the absence of the backend's ~25s heartbeat:
+// if nothing — not even a ping — arrives for this long, the stream is
+// assumed dead and force-reconnected.
+const SSE_WATCHDOG_TIMEOUT_MS = 40000;
+const SSE_WATCHDOG_CHECK_INTERVAL_MS = 10000;
 
 document.addEventListener('DOMContentLoaded', () => {
   fetchTickets();
@@ -107,6 +117,8 @@ async function openTicket(ticketId) {
     currentStreamAbort.abort();
     currentStreamAbort = null;
   }
+  clearTimeout(streamReconnectTimer);
+  streamReconnectTimer = null;
   stopAutoRefresh();
 
   currentTicketId = ticketId;
@@ -353,6 +365,10 @@ function closeDrawer() {
     currentStreamAbort.abort();
     currentStreamAbort = null;
   }
+  clearTimeout(streamReconnectTimer);
+  streamReconnectTimer = null;
+  clearInterval(streamWatchdogTimer);
+  streamWatchdogTimer = null;
   stopAutoRefresh();
   startTicketListRefresh(); // resume list polling
   currentTicketId = null;
@@ -366,6 +382,17 @@ function closeDrawer() {
 async function openTicketStream(ticketId) {
   const controller = new AbortController();
   currentStreamAbort = controller;
+  lastStreamActivity = Date.now();
+
+  clearInterval(streamWatchdogTimer);
+  streamWatchdogTimer = setInterval(() => {
+    if (Date.now() - lastStreamActivity > SSE_WATCHDOG_TIMEOUT_MS) {
+      console.warn('Ticket stream watchdog: no activity, forcing reconnect');
+      controller.abort();
+    }
+  }, SSE_WATCHDOG_CHECK_INTERVAL_MS);
+
+  let wasEverConnected = false;
 
   try {
     const resp = await fetch(`${CONFIG.basePath}/tickets/${ticketId}/stream`, {
@@ -381,16 +408,28 @@ async function openTicketStream(ticketId) {
       const { done, value } = await reader.read();
       if (done) break;
 
+      lastStreamActivity = Date.now();
       buf += decoder.decode(value, { stream: true });
       const frames = buf.split('\n\n');
       buf = frames.pop();
 
       for (const f of frames) {
         const line = f.split('\n').find((l) => l.startsWith('data:'));
-        if (!line) continue; // ignore ": ping" heartbeats and other comment lines
+        if (!line) continue; // ignore raw comment lines, if any
 
         const msg = JSON.parse(line.slice(5).trim());
-        if (msg.type === 'connected') continue;
+        if (msg.type === 'ping') continue; // liveness signal only
+        if (msg.type === 'connected') {
+          // A second (or later) "connected" means we reconnected after a
+          // drop — reload once to backfill anything missed while down, and
+          // stop the polling fallback now that the stream is back.
+          if (wasEverConnected && currentTicketId === ticketId) {
+            stopAutoRefresh();
+            loadTicketDetails();
+          }
+          wasEverConnected = true;
+          continue;
+        }
 
         // only append messages relevant to the ticket currently open
         if (currentTicketId === ticketId) {
@@ -398,12 +437,32 @@ async function openTicketStream(ticketId) {
         }
       }
     }
+    // Stream ended without an error (server closed it gracefully) — this
+    // produces no exception, so it must be handled the same as a failure.
+    scheduleStreamReconnect(ticketId);
   } catch (e) {
-    if (!controller.signal.aborted) {
-      console.warn('Ticket stream failed, falling back to polling', e);
-      startAutoRefresh(); // fallback to polling
-    }
+    // Reconnect on both a genuine network error and a watchdog-forced abort.
+    // An abort caused by the user closing the drawer / switching tickets is
+    // a no-op in scheduleStreamReconnect, since currentTicketId will no
+    // longer match `ticketId` by the time this runs.
+    console.warn('Ticket stream disconnected, will retry', e);
+    scheduleStreamReconnect(ticketId);
+  } finally {
+    clearInterval(streamWatchdogTimer);
+    streamWatchdogTimer = null;
   }
+}
+
+function scheduleStreamReconnect(ticketId) {
+  if (currentTicketId !== ticketId) return; // drawer moved on / closed
+  startAutoRefresh(); // keep polling as a safety net while the stream retries
+  clearTimeout(streamReconnectTimer);
+  streamReconnectTimer = setTimeout(() => {
+    streamReconnectTimer = null;
+    if (currentTicketId === ticketId) {
+      openTicketStream(ticketId);
+    }
+  }, 3000);
 }
 
 /* =====================================================

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -11,9 +11,6 @@ let lastStreamActivity = 0;
 // handler below for why that matters. Reset only when switching/closing a
 // ticket, not on every reconnect.
 let streamEverConnected = false;
-// Prevents openTicket() from being re-entered (e.g. a fast double-click)
-// before its first invocation's async work has finished.
-let isOpeningTicket = false;
 
 // A connection that's gone silently stale (a graceful close produces no
 // fetch error) is detected by the absence of the backend's ~25s heartbeat:
@@ -45,12 +42,8 @@ function authHeaders(withJsonContentType) {
    ===================================================== */
 
 function restrictServiceFilterByRole() {
-  let roles;
-  try {
-    roles = JSON.parse(sessionStorage.getItem('roles') || '[]');
-  } catch (e) {
-    roles = []; // malformed session data fails closed (no services shown)
-  }
+  // getRoles() comes from style/js/roleCheck.js, loaded before this script.
+  const roles = getRoles();
   if (roles.includes('superAdmin')) return; // sees every service, no restriction
 
   const allowedServices = Object.entries(TICKET_ROLE_SERVICE_MAP)
@@ -166,35 +159,44 @@ function renderTicketTable(tickets) {
    OPEN TICKET (DRAWER)
    ===================================================== */
 
-async function openTicket(ticketId) {
-  // Guard against re-entry (e.g. a fast double-click on "View") — without
-  // this, two concurrent invocations could each start their own stream, and
-  // only the second's AbortController/watchdog would remain reachable via
-  // the shared module-level variables, leaking the first connection.
-  if (isOpeningTicket) return;
-  isOpeningTicket = true;
-
-  try {
-    // abort any previous stream before switching tickets
-    if (currentStreamAbort) {
-      currentStreamAbort.abort();
-      currentStreamAbort = null;
-    }
-    clearTimeout(streamReconnectTimer);
-    streamReconnectTimer = null;
-    clearInterval(streamWatchdogTimer);
-    streamWatchdogTimer = null;
-    stopAutoRefresh();
-
-    currentTicketId = ticketId;
-    streamEverConnected = false;
-    stopTicketListRefresh(); // pause list polling while drawer is open
-    await loadTicketDetails();
-    openDrawer();
-    openTicketStream(ticketId);
-  } finally {
-    isOpeningTicket = false;
+// Aborts the in-flight stream (if any) and clears every timer associated
+// with it. Shared by openTicket() (switching to a different ticket) and
+// closeDrawer() so the two can't drift out of sync with each other.
+function teardownStream() {
+  if (currentStreamAbort) {
+    currentStreamAbort.abort();
+    currentStreamAbort = null;
   }
+  clearTimeout(streamReconnectTimer);
+  streamReconnectTimer = null;
+  clearInterval(streamWatchdogTimer);
+  streamWatchdogTimer = null;
+  stopAutoRefresh();
+}
+
+async function openTicket(ticketId) {
+  teardownStream(); // stop whatever ticket's stream was previously open
+
+  currentTicketId = ticketId;
+  streamEverConnected = false;
+  stopTicketListRefresh(); // pause list polling while drawer is open
+
+  // Fetching the ticket's details and opening its live stream don't depend
+  // on each other — start both immediately instead of waiting for the
+  // details fetch to finish before connecting the stream.
+  const detailsPromise = loadTicketDetails();
+  openTicketStream(ticketId);
+  await detailsPromise;
+
+  // The admin may have clicked a different ticket before this one's details
+  // finished loading — if so, let that newer call own opening the drawer
+  // instead of us popping it open for the wrong ticket. (This replaces a
+  // previous re-entrancy guard that blocked a second click outright, even
+  // when it was for a different ticket than the first.) loadTicketDetails()
+  // already guards its own populateDrawer() call the same way.
+  if (currentTicketId !== ticketId) return;
+
+  openDrawer();
 }
 
 /* =====================================================
@@ -256,7 +258,9 @@ function populateDrawer(ticket) {
 
   container.innerHTML = '';
 
-  (ticket.messages || []).forEach((msg) => renderMessage(msg, container));
+  (ticket.messages || []).forEach((msg) =>
+    renderMessage(msg, container, { skipDedupCheck: true })
+  );
 
   // Only auto-scroll to the newest message if the admin was already reading
   // the bottom of the thread; otherwise a background poll/reconnect/status
@@ -270,11 +274,11 @@ function populateDrawer(ticket) {
    RENDER A SINGLE MESSAGE BUBBLE
    ===================================================== */
 
-function renderMessage(msg, container) {
-  container = container || document.getElementById('messageContainer');
-
-  // avoid duplicate rendering (e.g. SSE echo of a message already loaded)
-  if (msg.id !== undefined && msg.id !== null) {
+function renderMessage(msg, container, { skipDedupCheck = false } = {}) {
+  // avoid duplicate rendering (e.g. SSE echo of a message already loaded).
+  // Callers that just cleared `container` (a full rebuild) can skip this —
+  // there's nothing in it yet for the check to find.
+  if (!skipDedupCheck && msg.id !== undefined && msg.id !== null) {
     const existing = container.querySelector(`[data-msg-id="${msg.id}"]`);
     if (existing) return;
   }
@@ -431,15 +435,7 @@ function closeDrawer() {
   document.getElementById('ticketDrawer').classList.remove('open');
   document.getElementById('drawerOverlay').classList.remove('open');
 
-  if (currentStreamAbort) {
-    currentStreamAbort.abort();
-    currentStreamAbort = null;
-  }
-  clearTimeout(streamReconnectTimer);
-  streamReconnectTimer = null;
-  clearInterval(streamWatchdogTimer);
-  streamWatchdogTimer = null;
-  stopAutoRefresh();
+  teardownStream();
   startTicketListRefresh(); // resume list polling
   currentTicketId = null;
   streamEverConnected = false;

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -19,17 +19,40 @@ let streamEverConnected = false;
 const SSE_WATCHDOG_TIMEOUT_MS = 40000;
 const SSE_WATCHDOG_CHECK_INTERVAL_MS = 10000;
 
-// Mirrors the backend's TICKET_SERVICE_ROLE_MAP (config/constants.js) —
-// must stay in sync. The backend enforces this regardless of what's shown
-// here; this is purely UX so a department admin isn't offered filter
-// options that would always come back empty (or a 403).
-const TICKET_ROLE_SERVICE_MAP = {
-  maintenanceAdmin: 'Maintenance',
-  housekeepingAdmin: 'Housekeeping',
-  foodAdmin: 'Food',
-  travelAdmin: 'Travel',
-  officeAdmin: 'Other'
+// Mirror of the backend's TICKET_SERVICE_ROLE_MAP (config/constants.js) —
+// service -> allowed roles, in the exact order the admin filter renders.
+// Must stay in sync with the backend, which enforces this regardless of what's
+// shown here; this is purely a UX filter so a department admin isn't offered
+// filter options that would always come back empty (or a 403). Unlike the old
+// role->single-service map, a role can now map to MULTIPLE services (e.g.
+// officeAdmin covers both "Raj Sharan" and "Others"), so allowed services are
+// computed by scanning this map the same way getAllowedServices does on the
+// backend. IT ([]) is superAdmin-only.
+const TICKET_SERVICE_ROLE_MAP = {
+  Electrical: ['electricalAdmin'],
+  Housekeeping: ['housekeepingAdmin'],
+  Maintenance: ['maintenanceAdmin'],
+  'Raj Prasad': ['foodAdmin'],
+  'Raj Adhyayan': ['adhyayanAdmin'],
+  'Raj Sharan': ['officeAdmin'],
+  'Raj Pravas': ['travelAdmin'],
+  'Raj Utsav': ['utsavAdmin'],
+  WiFi: ['wifiAdmin'],
+  'Payment/Accounts': ['accountsAdmin'],
+  IT: [],
+  Others: ['officeAdmin']
 };
+
+// Computes the services a set of roles may access by scanning the map above —
+// mirrors the backend's getAllowedServices (minus the superAdmin short-circuit,
+// which callers handle). A service is allowed if any of its roles is held.
+function getAllowedServicesForRoles(roles) {
+  const allowed = [];
+  for (const [service, serviceRoles] of Object.entries(TICKET_SERVICE_ROLE_MAP)) {
+    if (serviceRoles.some((r) => roles.includes(r))) allowed.push(service);
+  }
+  return allowed;
+}
 
 function authHeaders(withJsonContentType) {
   const headers = { Authorization: `Bearer ${sessionStorage.getItem('token')}` };
@@ -46,9 +69,7 @@ function restrictServiceFilterByRole() {
   const roles = getRoles();
   if (roles.includes('superAdmin')) return; // sees every service, no restriction
 
-  const allowedServices = Object.entries(TICKET_ROLE_SERVICE_MAP)
-    .filter(([role]) => roles.includes(role))
-    .map(([, service]) => service);
+  const allowedServices = getAllowedServicesForRoles(roles);
 
   const select = document.getElementById('serviceFilter');
   Array.from(select.options).forEach((opt) => {

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -103,6 +103,9 @@ async function fetchTickets() {
     const res = await fetch(`${CONFIG.basePath}/tickets?${params.toString()}`, {
       headers: authHeaders()
     });
+    // fetch only rejects on network errors, not on HTTP 4xx/5xx — guard so an
+    // error response doesn't wipe the table to empty; keep the last-good rows.
+    if (!res.ok) throw new Error(`Request failed: ${res.status}`);
 
     const result = await res.json();
     renderTicketTable(result.data || []);
@@ -175,6 +178,12 @@ function teardownStream() {
 }
 
 async function openTicket(ticketId) {
+  // The list embeds an encodeURIComponent'd id in its inline onclick; decode
+  // it back to the raw id so currentTicketId matches the keys used by
+  // getLastSeen(t.id) in the table (a no-op for the current hex ids, but keeps
+  // unread-tracking correct if the id format ever gains encodable characters).
+  ticketId = decodeURIComponent(ticketId);
+
   teardownStream(); // stop whatever ticket's stream was previously open
 
   currentTicketId = ticketId;
@@ -186,7 +195,7 @@ async function openTicket(ticketId) {
   // details fetch to finish before connecting the stream.
   const detailsPromise = loadTicketDetails();
   openTicketStream(ticketId);
-  await detailsPromise;
+  const loaded = await detailsPromise;
 
   // The admin may have clicked a different ticket before this one's details
   // finished loading — if so, let that newer call own opening the drawer
@@ -196,6 +205,12 @@ async function openTicket(ticketId) {
   // already guards its own populateDrawer() call the same way.
   if (currentTicketId !== ticketId) return;
 
+  // Don't open a blank drawer on a failed load — surface the error instead.
+  if (!loaded) {
+    alert('Failed to load ticket. Please try again.');
+    return;
+  }
+
   openDrawer();
 }
 
@@ -203,23 +218,33 @@ async function openTicket(ticketId) {
    LOAD TICKET DETAILS (MESSAGES)
    ===================================================== */
 
+// Returns true if the drawer was populated for the current ticket, false on
+// any error or if the request was superseded. Callers that opened the drawer
+// (openTicket) use this to surface an error instead of showing an empty
+// drawer; background callers (polling, SSE reload) ignore the result. It
+// deliberately does NOT alert on its own — that would spam on every 60s poll
+// or reconnect reload.
 async function loadTicketDetails() {
   const targetTicketId = currentTicketId;
-  if (!targetTicketId) return;
+  if (!targetTicketId) return false;
 
   try {
     const res = await fetch(`${CONFIG.basePath}/tickets/${targetTicketId}`, {
       headers: authHeaders()
     });
+    // Guard on HTTP status + payload so an error response doesn't reach
+    // populateDrawer(undefined) and throw while silently opening an empty drawer.
+    if (!res.ok) throw new Error(`Request failed: ${res.status}`);
 
     const result = await res.json();
     const ticket = result.data;
+    if (!ticket) throw new Error('Ticket data missing from response');
 
     // The admin may have switched to a different ticket (or closed the
     // drawer) while this fetch was in flight — don't let a slow response
     // for the OLD ticket overwrite the NOW-current ticket's drawer/unread
     // state.
-    if (currentTicketId !== targetTicketId) return;
+    if (currentTicketId !== targetTicketId) return false;
 
     populateDrawer(ticket);
 
@@ -228,8 +253,10 @@ async function loadTicketDetails() {
       const lastMsg = ticket.messages[ticket.messages.length - 1];
       setLastSeen(targetTicketId, lastMsg.createdAt);
     }
+    return true;
   } catch (e) {
     console.error('Failed to load ticket details', e);
+    return false;
   }
 }
 
@@ -248,7 +275,17 @@ function populateDrawer(ticket) {
     <p><b>App Version:</b> ${escapeHtml(ticket.app_version) || '-'}</p>
   `;
 
-  document.getElementById('statusUpdateSelect').value = ticket.status;
+  const statusSelect = document.getElementById('statusUpdateSelect');
+  statusSelect.value = ticket.status;
+  // A closed ticket can't be reopened by an admin (the backend rejects any
+  // status change on it), so lock the control + button rather than letting a
+  // click PATCH a value the server will 400 on. The disabled "Closed" option
+  // in the markup lets the select still display the closed state correctly
+  // instead of rendering blank (selectedIndex -1).
+  const isClosed = ticket.status === 'closed';
+  statusSelect.disabled = isClosed;
+  const updateStatusBtn = document.getElementById('updateStatusBtn');
+  if (updateStatusBtn) updateStatusBtn.disabled = isClosed;
 
   const container = document.getElementById('messageContainer');
 
@@ -384,11 +421,14 @@ async function sendReply() {
   if (!message || !currentTicketId) return;
 
   try {
-    await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}/messages`, {
+    const res = await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}/messages`, {
       method: 'POST',
       headers: authHeaders(true),
       body: JSON.stringify({ message })
     });
+    // fetch doesn't reject on 4xx/5xx — without this, a failed send would clear
+    // the textarea and reload as if it succeeded, silently losing the reply.
+    if (!res.ok) throw new Error(`Request failed: ${res.status}`);
 
     messageBox.value = '';
     await loadTicketDetails();
@@ -406,13 +446,17 @@ async function updateStatus() {
   if (!currentTicketId) return;
 
   const status = document.getElementById('statusUpdateSelect').value;
+  if (!status) return; // nothing selected (e.g. a closed ticket's blank state)
 
   try {
-    await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}/status`, {
+    const res = await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}/status`, {
       method: 'PATCH',
       headers: authHeaders(true),
       body: JSON.stringify({ status })
     });
+    // fetch doesn't reject on 4xx/5xx — without this the admin sees no error
+    // and believes the status changed when it didn't.
+    if (!res.ok) throw new Error(`Request failed: ${res.status}`);
 
     await loadTicketDetails();
     fetchTickets();
@@ -463,6 +507,15 @@ async function openTicketStream(ticketId) {
       headers: authHeaders(),
       signal: controller.signal
     });
+    // Without this, a non-2xx response still has a (small error JSON) body, so
+    // the reader below drains it, finds no frames, hits `done`, and reconnects
+    // every 3s forever — hammering the backend with a token/permission that
+    // will never work. A null body would also throw a TypeError here.
+    if (!resp.ok || !resp.body) {
+      const err = new Error(`Stream request failed: ${resp.status}`);
+      err.httpStatus = resp.status;
+      throw err;
+    }
 
     const reader = resp.body.getReader();
     const decoder = new TextDecoder();
@@ -481,7 +534,15 @@ async function openTicketStream(ticketId) {
         const line = f.split('\n').find((l) => l.startsWith('data:'));
         if (!line) continue; // ignore raw comment lines, if any
 
-        const msg = JSON.parse(line.slice(5).trim());
+        // One malformed frame must not throw out of the read loop (which would
+        // drop the connection + buffer and trigger a reconnect) — skip it.
+        let msg;
+        try {
+          msg = JSON.parse(line.slice(5).trim());
+        } catch (parseErr) {
+          console.warn('Ticket stream: skipping malformed frame', parseErr);
+          continue;
+        }
         if (msg.type === 'ping') continue; // liveness signal only
         if (msg.type === 'status_update') {
           // A status change isn't always paired with a new message (e.g. the
@@ -519,10 +580,17 @@ async function openTicketStream(ticketId) {
     // produces no exception, so it must be handled the same as a failure.
     scheduleStreamReconnect(ticketId);
   } catch (e) {
-    // Reconnect on both a genuine network error and a watchdog-forced abort.
-    // An abort caused by the user closing the drawer / switching tickets is
-    // a no-op in scheduleStreamReconnect, since currentTicketId will no
-    // longer match `ticketId` by the time this runs.
+    // A client error (expired token → 401, forbidden ticket/department → 403)
+    // will never succeed on retry, so don't storm the backend every 3s — fall
+    // back to slow polling instead. Network errors, 5xx, and watchdog-forced
+    // aborts are transient, so those still reconnect. An abort from the user
+    // closing the drawer / switching tickets is a no-op in
+    // scheduleStreamReconnect, since currentTicketId won't match by then.
+    if (e.httpStatus >= 400 && e.httpStatus < 500) {
+      console.error('Ticket stream auth/permission error, not retrying', e);
+      if (currentTicketId === ticketId) startAutoRefresh();
+      return;
+    }
     console.warn('Ticket stream disconnected, will retry', e);
     scheduleStreamReconnect(ticketId);
   } finally {

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -75,6 +75,15 @@ const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MB
 // to avoid leaking blobs.
 let activeObjectUrls = [];
 
+// Monotonic render "generation". Bumped on every full drawer rebuild
+// (populateDrawer) and on drawer close, so an authed-media fetch that was
+// started for an earlier render can tell — when it finally resolves — that its
+// target element has since been cleared/revoked, and self-revoke the object URL
+// it just minted instead of leaking it onto a detached element. Overlapping
+// re-renders (a 60s poll landing at the same time as an SSE reload) and closing
+// the drawer mid-fetch are exactly the cases this guards.
+let renderGeneration = 0;
+
 function trackObjectUrl(url) {
   activeObjectUrls.push(url);
   return url;
@@ -94,17 +103,48 @@ function serveMediaUrl(url) {
 }
 
 // Fetches a private attachment with auth, follows the backend's 302 to the
-// presigned S3 GET, and hands back a tracked object URL. Fails soft (logs) so
-// one broken attachment doesn't abort rendering the rest of the thread.
-async function loadAuthedMedia(url, onLoaded) {
+// presigned S3 GET, and hands back a tracked object URL (plus the underlying
+// blob, so the full-size modal can mint its own independent URL). Fails soft so
+// one broken attachment doesn't abort rendering the rest of the thread — on
+// failure it invokes onError so the caller can show a placeholder instead of a
+// silent blank thumbnail.
+async function loadAuthedMedia(url, onLoaded, onError) {
+  // Snapshot the render this fetch belongs to; compared after each await to
+  // detect a drawer rebuild/close that happened while we were in flight.
+  const generation = renderGeneration;
   try {
     const r = await fetch(serveMediaUrl(url), { headers: authHeaders() });
     if (!r.ok) throw new Error(`Media fetch failed: ${r.status}`);
     const blob = await r.blob();
-    onLoaded(trackObjectUrl(URL.createObjectURL(blob)));
+
+    const objectUrl = URL.createObjectURL(blob);
+    // The drawer was rebuilt (overlapping poll + SSE reload) or closed while
+    // this fetch was in flight — the element we'd attach to is detached and its
+    // siblings already revoked. Revoke the URL we just minted and bail so it
+    // doesn't leak onto a dead element.
+    if (generation !== renderGeneration) {
+      URL.revokeObjectURL(objectUrl);
+      return;
+    }
+    trackObjectUrl(objectUrl);
+    onLoaded(objectUrl, blob);
   } catch (e) {
     console.error('Failed to load attachment media', e);
+    // Only surface the failure if this render is still current — otherwise the
+    // slot has been superseded and there's nothing on screen to annotate.
+    if (generation === renderGeneration && onError) onError();
   }
+}
+
+// Swaps a still-loading thumbnail element for an inline error placeholder when
+// its media fetch fails, so the admin sees "failed to load" rather than a blank
+// broken box. A no-op if the element was already detached by a re-render.
+function replaceWithMediaError(el) {
+  if (!el.parentNode) return;
+  const ph = document.createElement('span');
+  ph.className = 'attachment-error';
+  ph.textContent = 'media failed to load';
+  el.replaceWith(ph);
 }
 
 // Renders a single attachment DTO ({ kind, contentType, url, expired }) as a
@@ -125,10 +165,14 @@ function renderAttachment(att, wrapper) {
     vid.muted = true;
     vid.preload = 'metadata';
     wrapper.appendChild(vid);
-    loadAuthedMedia(att.url, (objectUrl) => {
-      vid.src = objectUrl;
-      vid.onclick = () => openMediaModal('video', objectUrl);
-    });
+    loadAuthedMedia(
+      att.url,
+      (objectUrl, blob) => {
+        vid.src = objectUrl;
+        vid.onclick = () => openMediaModal('video', blob);
+      },
+      () => replaceWithMediaError(vid)
+    );
     return;
   }
 
@@ -137,30 +181,47 @@ function renderAttachment(att, wrapper) {
   img.className = 'attachment-thumb';
   img.alt = 'attachment';
   wrapper.appendChild(img);
-  loadAuthedMedia(att.url, (objectUrl) => {
-    img.src = objectUrl;
-    img.onclick = () => openMediaModal('image', objectUrl);
-  });
+  loadAuthedMedia(
+    att.url,
+    (objectUrl, blob) => {
+      img.src = objectUrl;
+      img.onclick = () => openMediaModal('image', blob);
+    },
+    () => replaceWithMediaError(img)
+  );
 }
 
 /* =====================================================
    FULL-SIZE MEDIA MODAL
    ===================================================== */
 
-// Reuses the thumbnail's already-fetched object URL (owned by the
-// activeObjectUrls registry), so closing the modal must NOT revoke it.
-function openMediaModal(kind, objectUrl) {
+// The full-size modal owns its OWN object URL, minted here from the blob and
+// tracked separately from the thumbnail registry (activeObjectUrls). This
+// decoupling is deliberate: a background re-render (poll / SSE / reconnect)
+// revokes + re-mints every thumbnail URL, and if the modal reused a thumbnail's
+// URL that re-render would blank the image/video the admin is actively viewing.
+// Owning its own URL means the modal survives re-renders and is revoked only on
+// close (or when a different attachment is opened).
+let modalObjectUrl = null;
+
+function openMediaModal(kind, blob) {
   const overlay = document.getElementById('mediaModalOverlay');
   const content = document.getElementById('mediaModalContent');
   if (!overlay || !content) return;
   content.innerHTML = '';
+  // Release the previous modal's URL before minting a fresh one.
+  if (modalObjectUrl) {
+    URL.revokeObjectURL(modalObjectUrl);
+    modalObjectUrl = null;
+  }
+  modalObjectUrl = URL.createObjectURL(blob);
   const el =
     kind === 'video' ? document.createElement('video') : document.createElement('img');
   if (kind === 'video') {
     el.controls = true;
     el.autoplay = true;
   }
-  el.src = objectUrl;
+  el.src = modalObjectUrl;
   el.className = 'media-modal-media';
   content.appendChild(el);
   overlay.classList.add('open');
@@ -170,9 +231,13 @@ function closeMediaModal() {
   const overlay = document.getElementById('mediaModalOverlay');
   const content = document.getElementById('mediaModalContent');
   if (overlay) overlay.classList.remove('open');
-  // Clearing the content stops any playing video; the object URL itself is
-  // owned by the thumbnail registry, so don't revoke it here.
+  // Clearing the content stops any playing video.
   if (content) content.innerHTML = '';
+  // This URL is owned by the modal (see openMediaModal), so revoke it here.
+  if (modalObjectUrl) {
+    URL.revokeObjectURL(modalObjectUrl);
+    modalObjectUrl = null;
+  }
 }
 
 /* =====================================================
@@ -322,6 +387,7 @@ async function openTicket(ticketId) {
 
   teardownStream(); // stop whatever ticket's stream was previously open
   clearReplyFiles(); // drop any images composed for the previously-open ticket
+  closeMediaModal(); // close any full-size media left open from the prior ticket
 
   currentTicketId = ticketId;
   streamEverConnected = false;
@@ -402,10 +468,16 @@ async function loadTicketDetails() {
    ===================================================== */
 
 function populateDrawer(ticket) {
-  // This is a full rebuild of the drawer's media — release the previous
-  // render's object URLs (and close the modal, whose media may reference one of
-  // them) before minting fresh ones below.
-  closeMediaModal();
+  // This is a full rebuild of the drawer's media. Bump the render generation
+  // first so any authed-media fetch still in flight from a PREVIOUS render
+  // self-revokes instead of attaching a stale object URL to a detached element,
+  // then release the previous render's object URLs before minting fresh ones.
+  // NOTE: we deliberately do NOT close the media modal here — a background poll,
+  // SSE status_update, or reconnect reload re-runs this on the SAME ticket, and
+  // closing the modal would yank away the full-size image/video the admin is
+  // viewing. The modal owns its own object URL, so it survives this revoke; it
+  // is closed only on explicit drawer close / ticket switch.
+  renderGeneration++;
   revokeObjectUrls();
 
   document.getElementById('ticketTitle').innerText = `Ticket #${ticket.id} (${ticket.status})`;
@@ -670,40 +742,56 @@ function clearReplyFiles() {
 // Presigns + PUTs each picked image directly to S3, returning the attachment
 // refs to send with the message. Order-matched: the presign response's Nth
 // { key, uploadUrl } corresponds to the Nth requested file.
+//
+// Idempotent across retries: once a file's PUT succeeds we stamp its S3 key
+// onto the File object (`_uploadedKey`). If a later file in the same batch
+// fails and the admin hits Send again, we only presign/PUT the files that
+// haven't uploaded yet and reuse the stamped keys for the rest — otherwise a
+// retry would re-presign/re-PUT the already-uploaded files under brand-new
+// keys, orphaning the originals in the bucket. The stamps live only as long as
+// the File objects do (cleared with the batch on a successful send, or when the
+// admin removes/replaces a pick).
 async function uploadReplyImages(files) {
-  const presignRes = await fetch(`${CONFIG.basePath}/tickets/attachments/presign`, {
-    method: 'POST',
-    headers: authHeaders(true),
-    body: JSON.stringify({
-      files: files.map((f) => ({
-        filename: f.name,
-        contentType: f.type,
-        size: f.size,
-        kind: 'image'
-      }))
-    })
-  });
-  if (!presignRes.ok) throw new Error(`Presign failed: ${presignRes.status}`);
+  const pending = files.filter((f) => !f._uploadedKey);
 
-  const presigned = (await presignRes.json()).data || [];
-  if (presigned.length !== files.length) {
-    throw new Error('Presign returned an unexpected number of upload URLs');
-  }
-
-  const attachments = [];
-  for (let i = 0; i < files.length; i++) {
-    const f = files[i];
-    const { key, uploadUrl } = presigned[i];
-    // Content-Type MUST match what was signed, or S3 rejects the PUT.
-    const putRes = await fetch(uploadUrl, {
-      method: 'PUT',
-      body: f,
-      headers: { 'Content-Type': f.type }
+  if (pending.length) {
+    const presignRes = await fetch(`${CONFIG.basePath}/tickets/attachments/presign`, {
+      method: 'POST',
+      headers: authHeaders(true),
+      body: JSON.stringify({
+        files: pending.map((f) => ({
+          filename: f.name,
+          contentType: f.type,
+          size: f.size,
+          kind: 'image'
+        }))
+      })
     });
-    if (!putRes.ok) throw new Error(`Upload failed for "${f.name}": ${putRes.status}`);
-    attachments.push({ key, contentType: f.type, kind: 'image' });
+    if (!presignRes.ok) throw new Error(`Presign failed: ${presignRes.status}`);
+
+    const presigned = (await presignRes.json()).data || [];
+    if (presigned.length !== pending.length) {
+      throw new Error('Presign returned an unexpected number of upload URLs');
+    }
+
+    for (let i = 0; i < pending.length; i++) {
+      const f = pending[i];
+      const { key, uploadUrl } = presigned[i];
+      // Content-Type MUST match what was signed, or S3 rejects the PUT.
+      const putRes = await fetch(uploadUrl, {
+        method: 'PUT',
+        body: f,
+        headers: { 'Content-Type': f.type }
+      });
+      if (!putRes.ok) throw new Error(`Upload failed for "${f.name}": ${putRes.status}`);
+      // Stamp the key so a retry after a sibling's failure reuses this upload.
+      f._uploadedKey = key;
+    }
   }
-  return attachments;
+
+  // Return refs in the original pick order — a mix of freshly-uploaded files
+  // and any that succeeded on a prior attempt.
+  return files.map((f) => ({ key: f._uploadedKey, contentType: f.type, kind: 'image' }));
 }
 
 /* =====================================================
@@ -711,11 +799,20 @@ async function uploadReplyImages(files) {
    ===================================================== */
 
 async function sendReply() {
+  // Snapshot the target ticket (and its composed file batch) BEFORE any await.
+  // currentTicketId is global and the drawer's backdrop can close it — or the
+  // admin can switch tickets — mid-upload, at which point the global would point
+  // at a different ticket (or null). Everything below (upload, POST URL, and
+  // clearing the composer) must use these snapshots, and after each await we
+  // re-check that the drawer hasn't moved on, so we never POST to the wrong
+  // ticket (or `tickets/null/messages`) or wipe the now-current ticket's state.
+  const ticketId = currentTicketId;
+  const files = pendingReplyFiles;
   const messageBox = document.getElementById('adminMessage');
   const message = messageBox.value.trim();
-  const hasFiles = pendingReplyFiles.length > 0;
+  const hasFiles = files.length > 0;
   // Message text is optional when at least one image is attached.
-  if ((!message && !hasFiles) || !currentTicketId) return;
+  if ((!message && !hasFiles) || !ticketId) return;
 
   const sendBtn = document.getElementById('sendReplyBtn');
   if (sendBtn) sendBtn.disabled = true;
@@ -726,10 +823,13 @@ async function sendReply() {
     if (hasFiles) {
       // Upload first — the message must only reference successfully-uploaded
       // keys (the backend HeadObject-verifies every key before persisting).
-      body.attachments = await uploadReplyImages(pendingReplyFiles);
+      body.attachments = await uploadReplyImages(files);
+      // The admin may have switched/closed the ticket during the upload — don't
+      // POST this reply to whatever ticket is now open.
+      if (currentTicketId !== ticketId) return;
     }
 
-    const res = await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}/messages`, {
+    const res = await fetch(`${CONFIG.basePath}/tickets/${ticketId}/messages`, {
       method: 'POST',
       headers: authHeaders(true),
       body: JSON.stringify(body)
@@ -737,6 +837,11 @@ async function sendReply() {
     // fetch doesn't reject on 4xx/5xx — without this, a failed send would clear
     // the composer and reload as if it succeeded, silently losing the reply.
     if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+
+    // The POST landed on `ticketId`; if the drawer has since moved to a
+    // different ticket, don't clear that ticket's composer or reload its
+    // details on the back of this send.
+    if (currentTicketId !== ticketId) return;
 
     messageBox.value = '';
     clearReplyFiles();
@@ -792,6 +897,9 @@ function closeDrawer() {
 
   closeMediaModal();
   revokeObjectUrls(); // release fetched attachment blobs
+  // Invalidate any authed-media fetch still in flight so it self-revokes on
+  // resolve instead of leaking an object URL after the drawer is gone.
+  renderGeneration++;
   clearReplyFiles(); // drop any un-sent composed images
   teardownStream();
   startTicketListRefresh(); // resume list polling

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -61,6 +61,121 @@ function authHeaders(withJsonContentType) {
 }
 
 /* =====================================================
+   MEDIA ATTACHMENTS (auth-fetched -> object URLs)
+   ===================================================== */
+
+// Attachment limits — mirror the backend's presign validation so we reject
+// obviously bad picks locally (the backend is still the authoritative gate).
+const MAX_REPLY_IMAGES = 5;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+// The serve endpoint requires a Bearer header, so a plain <img src> would 401
+// (browsers can't attach headers to element loads). Every object URL we mint
+// from an auth'd fetch is tracked here and revoked on drawer close / re-render
+// to avoid leaking blobs.
+let activeObjectUrls = [];
+
+function trackObjectUrl(url) {
+  activeObjectUrls.push(url);
+  return url;
+}
+
+function revokeObjectUrls() {
+  activeObjectUrls.forEach((u) => URL.revokeObjectURL(u));
+  activeObjectUrls = [];
+}
+
+// The backend returns each attachment's `url` as an absolute path from the
+// domain root (e.g. /api/v1/admin/tickets/<id>/attachments/<id>). CONFIG.basePath
+// already ends in /api/v1/admin, so concatenating the two would double the
+// prefix — resolve the path against the API origin instead.
+function serveMediaUrl(url) {
+  return new URL(url, CONFIG.baseUrl).href;
+}
+
+// Fetches a private attachment with auth, follows the backend's 302 to the
+// presigned S3 GET, and hands back a tracked object URL. Fails soft (logs) so
+// one broken attachment doesn't abort rendering the rest of the thread.
+async function loadAuthedMedia(url, onLoaded) {
+  try {
+    const r = await fetch(serveMediaUrl(url), { headers: authHeaders() });
+    if (!r.ok) throw new Error(`Media fetch failed: ${r.status}`);
+    const blob = await r.blob();
+    onLoaded(trackObjectUrl(URL.createObjectURL(blob)));
+  } catch (e) {
+    console.error('Failed to load attachment media', e);
+  }
+}
+
+// Renders a single attachment DTO ({ kind, contentType, url, expired }) as a
+// clickable thumbnail into `wrapper`. Expired media (cleaned up after 60 days)
+// shows a placeholder instead of fetching.
+function renderAttachment(att, wrapper) {
+  if (att.expired) {
+    const ph = document.createElement('span');
+    ph.className = 'attachment-expired';
+    ph.textContent = 'media removed after 60 days';
+    wrapper.appendChild(ph);
+    return;
+  }
+
+  if (att.kind === 'video') {
+    const vid = document.createElement('video');
+    vid.className = 'attachment-thumb';
+    vid.muted = true;
+    vid.preload = 'metadata';
+    wrapper.appendChild(vid);
+    loadAuthedMedia(att.url, (objectUrl) => {
+      vid.src = objectUrl;
+      vid.onclick = () => openMediaModal('video', objectUrl);
+    });
+    return;
+  }
+
+  // default: image
+  const img = document.createElement('img');
+  img.className = 'attachment-thumb';
+  img.alt = 'attachment';
+  wrapper.appendChild(img);
+  loadAuthedMedia(att.url, (objectUrl) => {
+    img.src = objectUrl;
+    img.onclick = () => openMediaModal('image', objectUrl);
+  });
+}
+
+/* =====================================================
+   FULL-SIZE MEDIA MODAL
+   ===================================================== */
+
+// Reuses the thumbnail's already-fetched object URL (owned by the
+// activeObjectUrls registry), so closing the modal must NOT revoke it.
+function openMediaModal(kind, objectUrl) {
+  const overlay = document.getElementById('mediaModalOverlay');
+  const content = document.getElementById('mediaModalContent');
+  if (!overlay || !content) return;
+  content.innerHTML = '';
+  const el =
+    kind === 'video' ? document.createElement('video') : document.createElement('img');
+  if (kind === 'video') {
+    el.controls = true;
+    el.autoplay = true;
+  }
+  el.src = objectUrl;
+  el.className = 'media-modal-media';
+  content.appendChild(el);
+  overlay.classList.add('open');
+}
+
+function closeMediaModal() {
+  const overlay = document.getElementById('mediaModalOverlay');
+  const content = document.getElementById('mediaModalContent');
+  if (overlay) overlay.classList.remove('open');
+  // Clearing the content stops any playing video; the object URL itself is
+  // owned by the thumbnail registry, so don't revoke it here.
+  if (content) content.innerHTML = '';
+}
+
+/* =====================================================
    RESTRICT SERVICE FILTER TO THE LOGGED-IN ADMIN'S DEPARTMENT
    ===================================================== */
 
@@ -206,6 +321,7 @@ async function openTicket(ticketId) {
   ticketId = decodeURIComponent(ticketId);
 
   teardownStream(); // stop whatever ticket's stream was previously open
+  clearReplyFiles(); // drop any images composed for the previously-open ticket
 
   currentTicketId = ticketId;
   streamEverConnected = false;
@@ -286,6 +402,12 @@ async function loadTicketDetails() {
    ===================================================== */
 
 function populateDrawer(ticket) {
+  // This is a full rebuild of the drawer's media — release the previous
+  // render's object URLs (and close the modal, whose media may reference one of
+  // them) before minting fresh ones below.
+  closeMediaModal();
+  revokeObjectUrls();
+
   document.getElementById('ticketTitle').innerText = `Ticket #${ticket.id} (${ticket.status})`;
 
   document.getElementById('ticketMeta').innerHTML = `
@@ -295,6 +417,24 @@ function populateDrawer(ticket) {
     <p><b>OS:</b> ${escapeHtml(ticket.os) || '-'}</p>
     <p><b>App Version:</b> ${escapeHtml(ticket.app_version) || '-'}</p>
   `;
+
+  // Ticket-level attachments (message_id === null) — filed with the original
+  // request at creation time.
+  const ticketAttachments = document.getElementById('ticketAttachments');
+  if (ticketAttachments) {
+    ticketAttachments.innerHTML = '';
+    const atts = ticket.attachments || [];
+    if (atts.length) {
+      const label = document.createElement('div');
+      label.className = 'attachment-label';
+      label.textContent = 'Attachments';
+      ticketAttachments.appendChild(label);
+      const strip = document.createElement('div');
+      strip.className = 'attachment-strip';
+      atts.forEach((att) => renderAttachment(att, strip));
+      ticketAttachments.appendChild(strip);
+    }
+  }
 
   const statusSelect = document.getElementById('statusUpdateSelect');
   statusSelect.value = ticket.status;
@@ -346,10 +486,26 @@ function renderMessage(msg, container, { skipDedupCheck = false } = {}) {
   if (msg.id !== undefined && msg.id !== null) {
     div.setAttribute('data-msg-id', msg.id);
   }
-  div.innerHTML = `
-    <p>${escapeHtml(msg.message)}</p>
-    <span>${escapeHtml(msg.sender_type)} &bull; ${new Date(msg.createdAt).toLocaleString()}</span>
-  `;
+
+  // The message text is optional when the message carries at least one
+  // attachment (attachment-only reply) — skip the empty bubble in that case.
+  div.innerHTML = msg.message ? `<p>${escapeHtml(msg.message)}</p>` : '';
+
+  // Message-level attachments (images the admin/user attached to this reply,
+  // or the user's videos which admins can view but not upload).
+  if (Array.isArray(msg.attachments) && msg.attachments.length) {
+    const strip = document.createElement('div');
+    strip.className = 'attachment-strip';
+    msg.attachments.forEach((att) => renderAttachment(att, strip));
+    div.appendChild(strip);
+  }
+
+  const meta = document.createElement('span');
+  meta.innerHTML = `${escapeHtml(msg.sender_type)} &bull; ${new Date(
+    msg.createdAt
+  ).toLocaleString()}`;
+  div.appendChild(meta);
+
   container.appendChild(div);
 }
 
@@ -433,29 +589,163 @@ function toggleDebugRaw() {
 }
 
 /* =====================================================
+   REPLY IMAGE ATTACHMENTS (compose -> presign -> PUT -> send)
+   ===================================================== */
+
+// Images the admin has picked for the current reply but not yet sent. Admins
+// attach images only — video is user-only (the backend 400s an admin video).
+let pendingReplyFiles = [];
+// Local (browser) object URLs backing the compose-time preview thumbnails —
+// separate from activeObjectUrls (which back fetched, server-side media) so the
+// two lifecycles don't interfere.
+let replyPreviewObjectUrls = [];
+
+// Handler for the hidden file input's change event. Validates each pick locally
+// (image, ≤5 MB, ≤5 total) before adding it to the pending batch.
+function onReplyFilesPicked(input) {
+  const files = Array.from(input.files || []);
+  for (const f of files) {
+    if (pendingReplyFiles.length >= MAX_REPLY_IMAGES) {
+      alert(`You can attach at most ${MAX_REPLY_IMAGES} images per message.`);
+      break;
+    }
+    if (!f.type || !f.type.startsWith('image/')) {
+      alert(`"${f.name}" is not an image. Admins can attach images only.`);
+      continue;
+    }
+    if (f.size > MAX_IMAGE_BYTES) {
+      alert(`"${f.name}" is larger than 5 MB.`);
+      continue;
+    }
+    pendingReplyFiles.push(f);
+  }
+  // Reset so picking the same file again still fires `change`.
+  input.value = '';
+  renderReplyPreviews();
+}
+
+function removeReplyFile(idx) {
+  pendingReplyFiles.splice(idx, 1);
+  renderReplyPreviews();
+}
+
+function renderReplyPreviews() {
+  const strip = document.getElementById('replyPreviewStrip');
+  if (!strip) return;
+
+  // Rebuild the strip from scratch — release the previous preview URLs first.
+  replyPreviewObjectUrls.forEach((u) => URL.revokeObjectURL(u));
+  replyPreviewObjectUrls = [];
+  strip.innerHTML = '';
+
+  pendingReplyFiles.forEach((f, idx) => {
+    const item = document.createElement('div');
+    item.className = 'reply-preview-item';
+
+    const img = document.createElement('img');
+    const localUrl = URL.createObjectURL(f);
+    replyPreviewObjectUrls.push(localUrl);
+    img.src = localUrl;
+
+    const rm = document.createElement('span');
+    rm.className = 'reply-preview-remove';
+    rm.textContent = '×'; // ×
+    rm.title = 'Remove';
+    rm.onclick = () => removeReplyFile(idx);
+
+    item.appendChild(img);
+    item.appendChild(rm);
+    strip.appendChild(item);
+  });
+}
+
+function clearReplyFiles() {
+  pendingReplyFiles = [];
+  replyPreviewObjectUrls.forEach((u) => URL.revokeObjectURL(u));
+  replyPreviewObjectUrls = [];
+  const strip = document.getElementById('replyPreviewStrip');
+  if (strip) strip.innerHTML = '';
+}
+
+// Presigns + PUTs each picked image directly to S3, returning the attachment
+// refs to send with the message. Order-matched: the presign response's Nth
+// { key, uploadUrl } corresponds to the Nth requested file.
+async function uploadReplyImages(files) {
+  const presignRes = await fetch(`${CONFIG.basePath}/tickets/attachments/presign`, {
+    method: 'POST',
+    headers: authHeaders(true),
+    body: JSON.stringify({
+      files: files.map((f) => ({
+        filename: f.name,
+        contentType: f.type,
+        size: f.size,
+        kind: 'image'
+      }))
+    })
+  });
+  if (!presignRes.ok) throw new Error(`Presign failed: ${presignRes.status}`);
+
+  const presigned = (await presignRes.json()).data || [];
+  if (presigned.length !== files.length) {
+    throw new Error('Presign returned an unexpected number of upload URLs');
+  }
+
+  const attachments = [];
+  for (let i = 0; i < files.length; i++) {
+    const f = files[i];
+    const { key, uploadUrl } = presigned[i];
+    // Content-Type MUST match what was signed, or S3 rejects the PUT.
+    const putRes = await fetch(uploadUrl, {
+      method: 'PUT',
+      body: f,
+      headers: { 'Content-Type': f.type }
+    });
+    if (!putRes.ok) throw new Error(`Upload failed for "${f.name}": ${putRes.status}`);
+    attachments.push({ key, contentType: f.type, kind: 'image' });
+  }
+  return attachments;
+}
+
+/* =====================================================
    SEND ADMIN REPLY
    ===================================================== */
 
 async function sendReply() {
   const messageBox = document.getElementById('adminMessage');
   const message = messageBox.value.trim();
-  if (!message || !currentTicketId) return;
+  const hasFiles = pendingReplyFiles.length > 0;
+  // Message text is optional when at least one image is attached.
+  if ((!message && !hasFiles) || !currentTicketId) return;
+
+  const sendBtn = document.getElementById('sendReplyBtn');
+  if (sendBtn) sendBtn.disabled = true;
 
   try {
+    const body = {};
+    if (message) body.message = message;
+    if (hasFiles) {
+      // Upload first — the message must only reference successfully-uploaded
+      // keys (the backend HeadObject-verifies every key before persisting).
+      body.attachments = await uploadReplyImages(pendingReplyFiles);
+    }
+
     const res = await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}/messages`, {
       method: 'POST',
       headers: authHeaders(true),
-      body: JSON.stringify({ message })
+      body: JSON.stringify(body)
     });
     // fetch doesn't reject on 4xx/5xx — without this, a failed send would clear
-    // the textarea and reload as if it succeeded, silently losing the reply.
+    // the composer and reload as if it succeeded, silently losing the reply.
     if (!res.ok) throw new Error(`Request failed: ${res.status}`);
 
     messageBox.value = '';
+    clearReplyFiles();
     await loadTicketDetails();
   } catch (e) {
     console.error('Failed to send reply', e);
     alert('Failed to send reply. Please try again.');
+  } finally {
+    if (sendBtn) sendBtn.disabled = false;
   }
 }
 
@@ -500,6 +790,9 @@ function closeDrawer() {
   document.getElementById('ticketDrawer').classList.remove('open');
   document.getElementById('drawerOverlay').classList.remove('open');
 
+  closeMediaModal();
+  revokeObjectUrls(); // release fetched attachment blobs
+  clearReplyFiles(); // drop any un-sent composed images
   teardownStream();
   startTicketListRefresh(); // resume list polling
   currentTicketId = null;

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -10,6 +10,24 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 /* =====================================================
+   HTML ESCAPING
+   Ticket description / service and chat messages are
+   submitted by app users, so they must be escaped before
+   being placed into innerHTML to avoid stored HTML injection
+   executing in an authenticated admin session.
+   ===================================================== */
+
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/* =====================================================
    UNREAD TRACKING (LAST MESSAGE BASED)
    ===================================================== */
 
@@ -65,14 +83,14 @@ function renderTicketTable(tickets) {
 
     const tr = document.createElement('tr');
     tr.innerHTML = `
-      <td>${dot}${t.id}</td>
-      <td>${t.issued_by}</td>
-      <td>${t.service}</td>
-      <td>${t.status}</td>
+      <td>${dot}${escapeHtml(t.id)}</td>
+      <td>${escapeHtml(t.issued_by)}</td>
+      <td>${escapeHtml(t.service)}</td>
+      <td>${escapeHtml(t.status)}</td>
       <td>${new Date(t.createdAt).toLocaleString()}</td>
       <td>${t.last_message_at ? new Date(t.last_message_at).toLocaleString() : '-'}</td>
       <td>
-        <button class="btn" onclick="openTicket('${t.id}')">View</button>
+        <button class="btn" onclick="openTicket('${encodeURIComponent(t.id)}')">View</button>
       </td>
     `;
     tbody.appendChild(tr);
@@ -136,11 +154,11 @@ function populateDrawer(ticket) {
   document.getElementById('ticketTitle').innerText = `Ticket #${ticket.id} (${ticket.status})`;
 
   document.getElementById('ticketMeta').innerHTML = `
-    <p><b>Service:</b> ${ticket.service}</p>
-    <p><b>Issued By:</b> ${ticket.issued_by}</p>
-    <p><b>Description:</b> ${ticket.description}</p>
-    <p><b>OS:</b> ${ticket.os || '-'}</p>
-    <p><b>App Version:</b> ${ticket.app_version || '-'}</p>
+    <p><b>Service:</b> ${escapeHtml(ticket.service)}</p>
+    <p><b>Issued By:</b> ${escapeHtml(ticket.issued_by)}</p>
+    <p><b>Description:</b> ${escapeHtml(ticket.description)}</p>
+    <p><b>OS:</b> ${escapeHtml(ticket.os) || '-'}</p>
+    <p><b>App Version:</b> ${escapeHtml(ticket.app_version) || '-'}</p>
   `;
 
   document.getElementById('statusUpdateSelect').value = ticket.status;
@@ -174,13 +192,13 @@ function renderMessage(msg, container) {
   }
 
   const div = document.createElement('div');
-  div.className = `message ${msg.sender_type}`;
+  div.className = msg.sender_type === 'admin' ? 'message admin' : 'message user';
   if (msg.id !== undefined && msg.id !== null) {
     div.setAttribute('data-msg-id', msg.id);
   }
   div.innerHTML = `
-    <p>${msg.message}</p>
-    <span>${msg.sender_type} &bull; ${new Date(msg.createdAt).toLocaleString()}</span>
+    <p>${escapeHtml(msg.message)}</p>
+    <span>${escapeHtml(msg.sender_type)} &bull; ${new Date(msg.createdAt).toLocaleString()}</span>
   `;
   container.appendChild(div);
 }

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -14,7 +14,48 @@ let lastStreamActivity = 0;
 const SSE_WATCHDOG_TIMEOUT_MS = 40000;
 const SSE_WATCHDOG_CHECK_INTERVAL_MS = 10000;
 
+// Mirrors the backend's TICKET_SERVICE_ROLE_MAP (config/constants.js) —
+// must stay in sync. The backend enforces this regardless of what's shown
+// here; this is purely UX so a department admin isn't offered filter
+// options that would always come back empty (or a 403).
+const TICKET_ROLE_SERVICE_MAP = {
+  maintenanceAdmin: 'Maintenance',
+  housekeepingAdmin: 'Housekeeping',
+  foodAdmin: 'Food',
+  travelAdmin: 'Travel',
+  officeAdmin: 'Other'
+};
+
+/* =====================================================
+   RESTRICT SERVICE FILTER TO THE LOGGED-IN ADMIN'S DEPARTMENT
+   ===================================================== */
+
+function restrictServiceFilterByRole() {
+  const roles = JSON.parse(sessionStorage.getItem('roles') || '[]');
+  if (roles.includes('superAdmin')) return; // sees every service, no restriction
+
+  const allowedServices = Object.entries(TICKET_ROLE_SERVICE_MAP)
+    .filter(([role]) => roles.includes(role))
+    .map(([, service]) => service);
+
+  const select = document.getElementById('serviceFilter');
+  Array.from(select.options).forEach((opt) => {
+    if (opt.value && !allowedServices.includes(opt.value)) {
+      opt.remove();
+    }
+  });
+
+  const allOption = select.querySelector('option[value=""]');
+  if (allOption) allOption.remove();
+
+  if (select.options.length > 0) {
+    select.value = select.options[0].value;
+  }
+  select.disabled = true;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  restrictServiceFilterByRole();
   fetchTickets();
   startTicketListRefresh();
 });

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -825,7 +825,7 @@ async function sendReply() {
   // re-check that the drawer hasn't moved on, so we never POST to the wrong
   // ticket (or `tickets/null/messages`) or wipe the now-current ticket's state.
   const ticketId = currentTicketId;
-  const files = pendingReplyFiles;
+  const files = pendingReplyFiles.slice();
   const messageBox = document.getElementById('adminMessage');
   const message = messageBox.value.trim();
   const hasFiles = files.length > 0;

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -86,7 +86,6 @@ let renderGeneration = 0;
 
 function trackObjectUrl(url) {
   activeObjectUrls.push(url);
-  return url;
 }
 
 function revokeObjectUrls() {
@@ -159,36 +158,35 @@ function renderAttachment(att, wrapper) {
     return;
   }
 
-  if (att.kind === 'video') {
-    const vid = document.createElement('video');
-    vid.className = 'attachment-thumb';
-    vid.muted = true;
-    vid.preload = 'metadata';
-    wrapper.appendChild(vid);
-    loadAuthedMedia(
-      att.url,
-      (objectUrl, blob) => {
-        vid.src = objectUrl;
-        vid.onclick = () => openMediaModal('video', blob);
-      },
-      () => replaceWithMediaError(vid)
-    );
-    return;
+  const kind = att.kind === 'video' ? 'video' : 'image';
+  const el = document.createElement(kind);
+  el.className = 'attachment-thumb';
+  if (kind === 'video') {
+    el.muted = true;
+    el.preload = 'metadata';
+  } else {
+    el.alt = 'attachment';
   }
-
-  // default: image
-  const img = document.createElement('img');
-  img.className = 'attachment-thumb';
-  img.alt = 'attachment';
-  wrapper.appendChild(img);
+  wrapper.appendChild(el);
   loadAuthedMedia(
     att.url,
     (objectUrl, blob) => {
-      img.src = objectUrl;
-      img.onclick = () => openMediaModal('image', blob);
+      el.src = objectUrl;
+      el.onclick = () => openMediaModal(kind, blob);
     },
-    () => replaceWithMediaError(img)
+    () => replaceWithMediaError(el)
   );
+}
+
+// Builds a `.attachment-strip` element populated via renderAttachment for each
+// item in `atts`, or returns null when there's nothing to show. Shared by
+// populateDrawer (ticket-level attachments) and renderMessage (per-message).
+function buildAttachmentStrip(atts) {
+  if (!Array.isArray(atts) || !atts.length) return null;
+  const strip = document.createElement('div');
+  strip.className = 'attachment-strip';
+  atts.forEach((att) => renderAttachment(att, strip));
+  return strip;
 }
 
 /* =====================================================
@@ -495,15 +493,12 @@ function populateDrawer(ticket) {
   const ticketAttachments = document.getElementById('ticketAttachments');
   if (ticketAttachments) {
     ticketAttachments.innerHTML = '';
-    const atts = ticket.attachments || [];
-    if (atts.length) {
+    const strip = buildAttachmentStrip(ticket.attachments);
+    if (strip) {
       const label = document.createElement('div');
       label.className = 'attachment-label';
       label.textContent = 'Attachments';
       ticketAttachments.appendChild(label);
-      const strip = document.createElement('div');
-      strip.className = 'attachment-strip';
-      atts.forEach((att) => renderAttachment(att, strip));
       ticketAttachments.appendChild(strip);
     }
   }
@@ -580,12 +575,8 @@ function renderMessage(msg, container, { skipDedupCheck = false } = {}) {
 
   // Message-level attachments (images the admin/user attached to this reply,
   // or the user's videos which admins can view but not upload).
-  if (Array.isArray(msg.attachments) && msg.attachments.length) {
-    const strip = document.createElement('div');
-    strip.className = 'attachment-strip';
-    msg.attachments.forEach((att) => renderAttachment(att, strip));
-    div.appendChild(strip);
-  }
+  const strip = buildAttachmentStrip(msg.attachments);
+  if (strip) div.appendChild(strip);
 
   const meta = document.createElement('span');
   meta.innerHTML = `${escapeHtml(msg.sender_type)} &bull; ${new Date(
@@ -798,19 +789,22 @@ async function uploadReplyImages(files) {
       throw new Error('Presign returned an unexpected number of upload URLs');
     }
 
-    for (let i = 0; i < pending.length; i++) {
-      const f = pending[i];
-      const { key, uploadUrl } = presigned[i];
-      // Content-Type MUST match what was signed, or S3 rejects the PUT.
-      const putRes = await fetch(uploadUrl, {
-        method: 'PUT',
-        body: f,
-        headers: { 'Content-Type': f.type }
-      });
-      if (!putRes.ok) throw new Error(`Upload failed for "${f.name}": ${putRes.status}`);
-      // Stamp the key so a retry after a sibling's failure reuses this upload.
-      f._uploadedKey = key;
-    }
+    // The PUTs are independent of each other — run them concurrently instead
+    // of one at a time.
+    await Promise.all(
+      pending.map(async (f, i) => {
+        const { key, uploadUrl } = presigned[i];
+        // Content-Type MUST match what was signed, or S3 rejects the PUT.
+        const putRes = await fetch(uploadUrl, {
+          method: 'PUT',
+          body: f,
+          headers: { 'Content-Type': f.type }
+        });
+        if (!putRes.ok) throw new Error(`Upload failed for "${f.name}": ${putRes.status}`);
+        // Stamp the key so a retry after a sibling's failure reuses this upload.
+        f._uploadedKey = key;
+      })
+    );
   }
 
   // Return refs in the original pick order — a mix of freshly-uploaded files

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -2,10 +2,18 @@ let ticketListInterval = null;
 let currentTicketId = null;
 let refreshInterval = null;
 let currentStreamAbort = null;
-let currentTicket = null;
 let streamReconnectTimer = null;
 let streamWatchdogTimer = null;
 let lastStreamActivity = 0;
+// Tracks whether the current ticket's stream has ever received a "connected"
+// frame. Lives at module scope (not inside openTicketStream) so it persists
+// across reconnect attempts for the same ticket — see the "connected" frame
+// handler below for why that matters. Reset only when switching/closing a
+// ticket, not on every reconnect.
+let streamEverConnected = false;
+// Prevents openTicket() from being re-entered (e.g. a fast double-click)
+// before its first invocation's async work has finished.
+let isOpeningTicket = false;
 
 // A connection that's gone silently stale (a graceful close produces no
 // fetch error) is detected by the absence of the backend's ~25s heartbeat:
@@ -26,12 +34,23 @@ const TICKET_ROLE_SERVICE_MAP = {
   officeAdmin: 'Other'
 };
 
+function authHeaders(withJsonContentType) {
+  const headers = { Authorization: `Bearer ${sessionStorage.getItem('token')}` };
+  if (withJsonContentType) headers['Content-Type'] = 'application/json';
+  return headers;
+}
+
 /* =====================================================
    RESTRICT SERVICE FILTER TO THE LOGGED-IN ADMIN'S DEPARTMENT
    ===================================================== */
 
 function restrictServiceFilterByRole() {
-  const roles = JSON.parse(sessionStorage.getItem('roles') || '[]');
+  let roles;
+  try {
+    roles = JSON.parse(sessionStorage.getItem('roles') || '[]');
+  } catch (e) {
+    roles = []; // malformed session data fails closed (no services shown)
+  }
   if (roles.includes('superAdmin')) return; // sees every service, no restriction
 
   const allowedServices = Object.entries(TICKET_ROLE_SERVICE_MAP)
@@ -51,7 +70,10 @@ function restrictServiceFilterByRole() {
   if (select.options.length > 0) {
     select.value = select.options[0].value;
   }
-  select.disabled = true;
+  // Only lock the dropdown when there's nothing to choose between — an admin
+  // with 2+ department roles (e.g. foodAdmin + travelAdmin) must still be
+  // able to switch between their own allowed services.
+  select.disabled = select.options.length <= 1;
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -59,24 +81,6 @@ document.addEventListener('DOMContentLoaded', () => {
   fetchTickets();
   startTicketListRefresh();
 });
-
-/* =====================================================
-   HTML ESCAPING
-   Ticket description / service and chat messages are
-   submitted by app users, so they must be escaped before
-   being placed into innerHTML to avoid stored HTML injection
-   executing in an authenticated admin session.
-   ===================================================== */
-
-function escapeHtml(value) {
-  if (value === null || value === undefined) return '';
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
 
 /* =====================================================
    UNREAD TRACKING (LAST MESSAGE BASED)
@@ -104,9 +108,7 @@ async function fetchTickets() {
 
   try {
     const res = await fetch(`${CONFIG.basePath}/tickets?${params.toString()}`, {
-      headers: {
-        Authorization: `Bearer ${sessionStorage.getItem('token')}`
-      }
+      headers: authHeaders()
     });
 
     const result = await res.json();
@@ -119,6 +121,8 @@ async function fetchTickets() {
 /* =====================================================
    RENDER TICKET TABLE (UNREAD INDICATOR)
    ===================================================== */
+
+let ticketTableEnhanced = false;
 
 function renderTicketTable(tickets) {
   const tbody = document.querySelector('#ticketTable tbody');
@@ -146,6 +150,16 @@ function renderTicketTable(tickets) {
     `;
     tbody.appendChild(tr);
   });
+
+  // enhanceTable's header enhancement is idempotent-guarded internally, but
+  // its search-box listener is not — only wire it up once (on first render)
+  // rather than re-binding a duplicate listener on every 10s poll.
+  if (!ticketTableEnhanced && typeof enhanceTable === 'function') {
+    // enableRowNumbers=false: the first column is the ticket id/unread-dot,
+    // not a row index — enhanceTable would otherwise overwrite it.
+    enhanceTable('ticketTable', 'ticketSearch', false);
+    ticketTableEnhanced = true;
+  }
 }
 
 /* =====================================================
@@ -153,20 +167,34 @@ function renderTicketTable(tickets) {
    ===================================================== */
 
 async function openTicket(ticketId) {
-  // abort any previous stream before switching tickets
-  if (currentStreamAbort) {
-    currentStreamAbort.abort();
-    currentStreamAbort = null;
-  }
-  clearTimeout(streamReconnectTimer);
-  streamReconnectTimer = null;
-  stopAutoRefresh();
+  // Guard against re-entry (e.g. a fast double-click on "View") — without
+  // this, two concurrent invocations could each start their own stream, and
+  // only the second's AbortController/watchdog would remain reachable via
+  // the shared module-level variables, leaking the first connection.
+  if (isOpeningTicket) return;
+  isOpeningTicket = true;
 
-  currentTicketId = ticketId;
-  stopTicketListRefresh(); // pause list polling while drawer is open
-  await loadTicketDetails();
-  openDrawer();
-  openTicketStream(ticketId);
+  try {
+    // abort any previous stream before switching tickets
+    if (currentStreamAbort) {
+      currentStreamAbort.abort();
+      currentStreamAbort = null;
+    }
+    clearTimeout(streamReconnectTimer);
+    streamReconnectTimer = null;
+    clearInterval(streamWatchdogTimer);
+    streamWatchdogTimer = null;
+    stopAutoRefresh();
+
+    currentTicketId = ticketId;
+    streamEverConnected = false;
+    stopTicketListRefresh(); // pause list polling while drawer is open
+    await loadTicketDetails();
+    openDrawer();
+    openTicketStream(ticketId);
+  } finally {
+    isOpeningTicket = false;
+  }
 }
 
 /* =====================================================
@@ -174,25 +202,29 @@ async function openTicket(ticketId) {
    ===================================================== */
 
 async function loadTicketDetails() {
-  if (!currentTicketId) return;
+  const targetTicketId = currentTicketId;
+  if (!targetTicketId) return;
 
   try {
-    const res = await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}`, {
-      headers: {
-        Authorization: `Bearer ${sessionStorage.getItem('token')}`
-      }
+    const res = await fetch(`${CONFIG.basePath}/tickets/${targetTicketId}`, {
+      headers: authHeaders()
     });
 
     const result = await res.json();
     const ticket = result.data;
-    currentTicket = ticket;
+
+    // The admin may have switched to a different ticket (or closed the
+    // drawer) while this fetch was in flight — don't let a slow response
+    // for the OLD ticket overwrite the NOW-current ticket's drawer/unread
+    // state.
+    if (currentTicketId !== targetTicketId) return;
 
     populateDrawer(ticket);
 
     // Mark ticket as read using LAST MESSAGE TIME, not current time
     if (ticket.messages && ticket.messages.length > 0) {
       const lastMsg = ticket.messages[ticket.messages.length - 1];
-      setLastSeen(currentTicketId, lastMsg.createdAt);
+      setLastSeen(targetTicketId, lastMsg.createdAt);
     }
   } catch (e) {
     console.error('Failed to load ticket details', e);
@@ -220,13 +252,16 @@ function populateDrawer(ticket) {
 
   const wasAtBottom =
     container.scrollTop + container.clientHeight >= container.scrollHeight - 10;
+  const scrollTopBeforeRebuild = container.scrollTop;
 
   container.innerHTML = '';
 
   (ticket.messages || []).forEach((msg) => renderMessage(msg, container));
 
-  container.scrollTop = container.scrollHeight;
-  void wasAtBottom;
+  // Only auto-scroll to the newest message if the admin was already reading
+  // the bottom of the thread; otherwise a background poll/reconnect/status
+  // update would yank them away from whatever they were reading.
+  container.scrollTop = wasAtBottom ? container.scrollHeight : scrollTopBeforeRebuild;
 
   renderDebugPanel(ticket.metadata);
 }
@@ -347,10 +382,7 @@ async function sendReply() {
   try {
     await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}/messages`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${sessionStorage.getItem('token')}`
-      },
+      headers: authHeaders(true),
       body: JSON.stringify({ message })
     });
 
@@ -374,10 +406,7 @@ async function updateStatus() {
   try {
     await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}/status`, {
       method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${sessionStorage.getItem('token')}`
-      },
+      headers: authHeaders(true),
       body: JSON.stringify({ status })
     });
 
@@ -413,7 +442,7 @@ function closeDrawer() {
   stopAutoRefresh();
   startTicketListRefresh(); // resume list polling
   currentTicketId = null;
-  currentTicket = null;
+  streamEverConnected = false;
 }
 
 /* =====================================================
@@ -433,11 +462,9 @@ async function openTicketStream(ticketId) {
     }
   }, SSE_WATCHDOG_CHECK_INTERVAL_MS);
 
-  let wasEverConnected = false;
-
   try {
     const resp = await fetch(`${CONFIG.basePath}/tickets/${ticketId}/stream`, {
-      headers: { Authorization: `Bearer ${sessionStorage.getItem('token')}` },
+      headers: authHeaders(),
       signal: controller.signal
     });
 
@@ -473,11 +500,16 @@ async function openTicketStream(ticketId) {
           // A second (or later) "connected" means we reconnected after a
           // drop — reload once to backfill anything missed while down, and
           // stop the polling fallback now that the stream is back.
-          if (wasEverConnected && currentTicketId === ticketId) {
+          // streamEverConnected lives at module scope (not local to this
+          // function) specifically so this check survives across the
+          // separate openTicketStream() invocation that scheduleStreamReconnect
+          // makes on each retry — a function-local flag would reset to false
+          // on every reconnect and this branch would never fire.
+          if (streamEverConnected && currentTicketId === ticketId) {
             stopAutoRefresh();
             loadTicketDetails();
           }
-          wasEverConnected = true;
+          streamEverConnected = true;
           continue;
         }
 

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -1,0 +1,421 @@
+let ticketListInterval = null;
+let currentTicketId = null;
+let refreshInterval = null;
+let currentStreamAbort = null;
+let currentTicket = null;
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchTickets();
+  startTicketListRefresh();
+});
+
+/* =====================================================
+   UNREAD TRACKING (LAST MESSAGE BASED)
+   ===================================================== */
+
+function getLastSeen(ticketId) {
+  return sessionStorage.getItem(`ticket_last_msg_seen_${ticketId}`);
+}
+
+function setLastSeen(ticketId, time) {
+  sessionStorage.setItem(`ticket_last_msg_seen_${ticketId}`, time);
+}
+
+/* =====================================================
+   FETCH TICKETS (LIST VIEW)
+   ===================================================== */
+
+async function fetchTickets() {
+  const status = document.getElementById('statusFilter').value;
+  const service = document.getElementById('serviceFilter').value;
+
+  const params = new URLSearchParams();
+  if (status) params.append('status', status);
+  if (service) params.append('service', service);
+
+  try {
+    const res = await fetch(`${CONFIG.basePath}/tickets?${params.toString()}`, {
+      headers: {
+        Authorization: `Bearer ${sessionStorage.getItem('token')}`
+      }
+    });
+
+    const result = await res.json();
+    renderTicketTable(result.data || []);
+  } catch (e) {
+    console.error('Failed to fetch tickets', e);
+  }
+}
+
+/* =====================================================
+   RENDER TICKET TABLE (UNREAD INDICATOR)
+   ===================================================== */
+
+function renderTicketTable(tickets) {
+  const tbody = document.querySelector('#ticketTable tbody');
+  tbody.innerHTML = '';
+
+  tickets.forEach((t) => {
+    const lastSeen = getLastSeen(t.id);
+    const lastMsg = t.last_message_at;
+
+    const unread = lastMsg && (!lastSeen || new Date(lastMsg) > new Date(lastSeen));
+
+    const dot = unread ? '<span class="unread-dot">&#9679;</span>' : '';
+
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${dot}${t.id}</td>
+      <td>${t.issued_by}</td>
+      <td>${t.service}</td>
+      <td>${t.status}</td>
+      <td>${new Date(t.createdAt).toLocaleString()}</td>
+      <td>${t.last_message_at ? new Date(t.last_message_at).toLocaleString() : '-'}</td>
+      <td>
+        <button class="btn" onclick="openTicket('${t.id}')">View</button>
+      </td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+/* =====================================================
+   OPEN TICKET (DRAWER)
+   ===================================================== */
+
+async function openTicket(ticketId) {
+  // abort any previous stream before switching tickets
+  if (currentStreamAbort) {
+    currentStreamAbort.abort();
+    currentStreamAbort = null;
+  }
+  stopAutoRefresh();
+
+  currentTicketId = ticketId;
+  stopTicketListRefresh(); // pause list polling while drawer is open
+  await loadTicketDetails();
+  openDrawer();
+  openTicketStream(ticketId);
+}
+
+/* =====================================================
+   LOAD TICKET DETAILS (MESSAGES)
+   ===================================================== */
+
+async function loadTicketDetails() {
+  if (!currentTicketId) return;
+
+  try {
+    const res = await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}`, {
+      headers: {
+        Authorization: `Bearer ${sessionStorage.getItem('token')}`
+      }
+    });
+
+    const result = await res.json();
+    const ticket = result.data;
+    currentTicket = ticket;
+
+    populateDrawer(ticket);
+
+    // Mark ticket as read using LAST MESSAGE TIME, not current time
+    if (ticket.messages && ticket.messages.length > 0) {
+      const lastMsg = ticket.messages[ticket.messages.length - 1];
+      setLastSeen(currentTicketId, lastMsg.createdAt);
+    }
+  } catch (e) {
+    console.error('Failed to load ticket details', e);
+  }
+}
+
+/* =====================================================
+   POPULATE DRAWER UI
+   ===================================================== */
+
+function populateDrawer(ticket) {
+  document.getElementById('ticketTitle').innerText = `Ticket #${ticket.id} (${ticket.status})`;
+
+  document.getElementById('ticketMeta').innerHTML = `
+    <p><b>Service:</b> ${ticket.service}</p>
+    <p><b>Issued By:</b> ${ticket.issued_by}</p>
+    <p><b>Description:</b> ${ticket.description}</p>
+    <p><b>OS:</b> ${ticket.os || '-'}</p>
+    <p><b>App Version:</b> ${ticket.app_version || '-'}</p>
+  `;
+
+  document.getElementById('statusUpdateSelect').value = ticket.status;
+
+  const container = document.getElementById('messageContainer');
+
+  const wasAtBottom =
+    container.scrollTop + container.clientHeight >= container.scrollHeight - 10;
+
+  container.innerHTML = '';
+
+  (ticket.messages || []).forEach((msg) => renderMessage(msg, container));
+
+  container.scrollTop = container.scrollHeight;
+  void wasAtBottom;
+
+  renderDebugPanel(ticket.metadata);
+}
+
+/* =====================================================
+   RENDER A SINGLE MESSAGE BUBBLE
+   ===================================================== */
+
+function renderMessage(msg, container) {
+  container = container || document.getElementById('messageContainer');
+
+  // avoid duplicate rendering (e.g. SSE echo of a message already loaded)
+  if (msg.id !== undefined && msg.id !== null) {
+    const existing = container.querySelector(`[data-msg-id="${msg.id}"]`);
+    if (existing) return;
+  }
+
+  const div = document.createElement('div');
+  div.className = `message ${msg.sender_type}`;
+  if (msg.id !== undefined && msg.id !== null) {
+    div.setAttribute('data-msg-id', msg.id);
+  }
+  div.innerHTML = `
+    <p>${msg.message}</p>
+    <span>${msg.sender_type} &bull; ${new Date(msg.createdAt).toLocaleString()}</span>
+  `;
+  container.appendChild(div);
+}
+
+/* =====================================================
+   APPEND A LIVE (SSE) MESSAGE
+   ===================================================== */
+
+function appendMessage(msg) {
+  const container = document.getElementById('messageContainer');
+  renderMessage(msg, container);
+  container.scrollTop = container.scrollHeight;
+
+  if (currentTicketId) {
+    setLastSeen(currentTicketId, msg.createdAt || new Date().toISOString());
+  }
+}
+
+/* =====================================================
+   DEBUG INFO PANEL (ticket.metadata)
+   ===================================================== */
+
+function renderDebugPanel(metadata) {
+  const grid = document.getElementById('debugKvGrid');
+  const rawJson = document.getElementById('debugRawJson');
+
+  grid.innerHTML = '';
+  rawJson.textContent = '';
+
+  if (!metadata || typeof metadata !== 'object' || Object.keys(metadata).length === 0) {
+    grid.innerHTML = '<span class="debug-empty">No diagnostic data available for this ticket.</span>';
+    return;
+  }
+
+  const flat = flattenObject(metadata);
+  Object.keys(flat).forEach((key) => {
+    const keyEl = document.createElement('div');
+    keyEl.className = 'debug-key';
+    keyEl.textContent = key;
+
+    const valEl = document.createElement('div');
+    valEl.className = 'debug-value';
+    valEl.textContent = flat[key];
+
+    grid.appendChild(keyEl);
+    grid.appendChild(valEl);
+  });
+
+  rawJson.textContent = JSON.stringify(metadata, null, 2);
+}
+
+function flattenObject(obj, prefix = '', result = {}) {
+  Object.keys(obj || {}).forEach((key) => {
+    const value = obj[key];
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    if (value === null || value === undefined) {
+      result[path] = String(value);
+    } else if (typeof value === 'object' && !Array.isArray(value)) {
+      flattenObject(value, path, result);
+    } else if (Array.isArray(value)) {
+      result[path] = JSON.stringify(value);
+    } else {
+      result[path] = String(value);
+    }
+  });
+  return result;
+}
+
+function toggleDebugPanel() {
+  const body = document.getElementById('debugPanelBody');
+  const icon = document.getElementById('debugPanelToggleIcon');
+  body.classList.toggle('open');
+  icon.innerHTML = body.classList.contains('open') ? '&#9662;' : '&#9656;';
+}
+
+function toggleDebugRaw() {
+  const rawJson = document.getElementById('debugRawJson');
+  const toggle = document.getElementById('debugRawToggle');
+  rawJson.classList.toggle('open');
+  toggle.textContent = rawJson.classList.contains('open') ? 'Hide raw JSON' : 'Show raw JSON';
+}
+
+/* =====================================================
+   SEND ADMIN REPLY
+   ===================================================== */
+
+async function sendReply() {
+  const messageBox = document.getElementById('adminMessage');
+  const message = messageBox.value.trim();
+  if (!message || !currentTicketId) return;
+
+  try {
+    await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${sessionStorage.getItem('token')}`
+      },
+      body: JSON.stringify({ message })
+    });
+
+    messageBox.value = '';
+    await loadTicketDetails();
+  } catch (e) {
+    console.error('Failed to send reply', e);
+    alert('Failed to send reply. Please try again.');
+  }
+}
+
+/* =====================================================
+   UPDATE TICKET STATUS
+   ===================================================== */
+
+async function updateStatus() {
+  if (!currentTicketId) return;
+
+  const status = document.getElementById('statusUpdateSelect').value;
+
+  try {
+    await fetch(`${CONFIG.basePath}/tickets/${currentTicketId}/status`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${sessionStorage.getItem('token')}`
+      },
+      body: JSON.stringify({ status })
+    });
+
+    await loadTicketDetails();
+    fetchTickets();
+  } catch (e) {
+    console.error('Failed to update status', e);
+    alert('Failed to update status. Please try again.');
+  }
+}
+
+/* =====================================================
+   DRAWER CONTROL
+   ===================================================== */
+
+function openDrawer() {
+  document.getElementById('ticketDrawer').classList.add('open');
+  document.getElementById('drawerOverlay').classList.add('open');
+}
+
+function closeDrawer() {
+  document.getElementById('ticketDrawer').classList.remove('open');
+  document.getElementById('drawerOverlay').classList.remove('open');
+
+  if (currentStreamAbort) {
+    currentStreamAbort.abort();
+    currentStreamAbort = null;
+  }
+  stopAutoRefresh();
+  startTicketListRefresh(); // resume list polling
+  currentTicketId = null;
+  currentTicket = null;
+}
+
+/* =====================================================
+   OPEN TICKET CONVERSATION STREAM (FETCH-BASED SSE)
+   ===================================================== */
+
+async function openTicketStream(ticketId) {
+  const controller = new AbortController();
+  currentStreamAbort = controller;
+
+  try {
+    const resp = await fetch(`${CONFIG.basePath}/tickets/${ticketId}/stream`, {
+      headers: { Authorization: `Bearer ${sessionStorage.getItem('token')}` },
+      signal: controller.signal
+    });
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buf += decoder.decode(value, { stream: true });
+      const frames = buf.split('\n\n');
+      buf = frames.pop();
+
+      for (const f of frames) {
+        const line = f.split('\n').find((l) => l.startsWith('data:'));
+        if (!line) continue; // ignore ": ping" heartbeats and other comment lines
+
+        const msg = JSON.parse(line.slice(5).trim());
+        if (msg.type === 'connected') continue;
+
+        // only append messages relevant to the ticket currently open
+        if (currentTicketId === ticketId) {
+          appendMessage(msg);
+        }
+      }
+    }
+  } catch (e) {
+    if (!controller.signal.aborted) {
+      console.warn('Ticket stream failed, falling back to polling', e);
+      startAutoRefresh(); // fallback to polling
+    }
+  }
+}
+
+/* =====================================================
+   AUTO REFRESH (POLLING FALLBACK FOR OPEN TICKET)
+   ===================================================== */
+
+function startAutoRefresh() {
+  stopAutoRefresh();
+  refreshInterval = setInterval(loadTicketDetails, 60000);
+}
+
+function stopAutoRefresh() {
+  if (refreshInterval) {
+    clearInterval(refreshInterval);
+    refreshInterval = null;
+  }
+}
+
+/* =====================================================
+   TICKET LIST POLLING (UNREAD DOTS)
+   ===================================================== */
+
+function startTicketListRefresh() {
+  stopTicketListRefresh();
+  ticketListInterval = setInterval(fetchTickets, 10000);
+}
+
+function stopTicketListRefresh() {
+  if (ticketListInterval) {
+    clearInterval(ticketListInterval);
+    ticketListInterval = null;
+  }
+}

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -419,6 +419,15 @@ async function openTicketStream(ticketId) {
 
         const msg = JSON.parse(line.slice(5).trim());
         if (msg.type === 'ping') continue; // liveness signal only
+        if (msg.type === 'status_update') {
+          // A status change isn't always paired with a new message (e.g. the
+          // ticket owner tapping "Close Ticket" from the app) — reload so the
+          // status badge/dropdown reflect it without a manual refresh.
+          if (currentTicketId === ticketId) {
+            loadTicketDetails();
+          }
+          continue;
+        }
         if (msg.type === 'connected') {
           // A second (or later) "connected" means we reconnected after a
           // drop — reload once to backfill anything missed while down, and

--- a/admin/ticket/tickets.js
+++ b/admin/ticket/tickets.js
@@ -1016,9 +1016,16 @@ async function openTicketStream(ticketId) {
           continue;
         }
 
-        // only append messages relevant to the ticket currently open
+        // only render messages relevant to the ticket currently open
         if (currentTicketId === ticketId) {
-          appendMessage(msg);
+          // The SSE frame flags attachments but can't carry them (the serve
+          // URL is audience-specific), so reload to backfill the image/video
+          // thumbnails; text-only messages just append in place.
+          if (msg.hasAttachments) {
+            loadTicketDetails();
+          } else {
+            appendMessage(msg);
+          }
         }
       }
     }

--- a/style/js/htmlEscape.js
+++ b/style/js/htmlEscape.js
@@ -1,0 +1,12 @@
+// Shared HTML-escaping helper. Any page rendering server/user-submitted
+// content via innerHTML must escape it first to avoid stored HTML/script
+// injection executing in an authenticated admin session.
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/style/js/roleCheck.js
+++ b/style/js/roleCheck.js
@@ -7,7 +7,12 @@ function checkRoleAccess(allowedRoles) {
     return;
   }
 
-  const roles    = JSON.parse(sessionStorage.getItem('roles') || '[]');
+  let roles;
+  try {
+    roles = JSON.parse(sessionStorage.getItem('roles') || '[]');
+  } catch (e) {
+    roles = []; // malformed session data must fail closed, not throw past the check
+  }
   const currentPage = window.location.pathname.split('/').pop();
 
   const hasAccess = roles.some((role) => allowedRoles.includes(role));
@@ -64,7 +69,12 @@ function logout() {
 }
 
 function getHomePageForRole() {
-  const roles = JSON.parse(sessionStorage.getItem('roles') || '[]');
+  let roles;
+  try {
+    roles = JSON.parse(sessionStorage.getItem('roles') || '[]');
+  } catch (e) {
+    roles = [];
+  }
 
   // Check if user has any valid roles
   const validRoles = [

--- a/style/js/roleCheck.js
+++ b/style/js/roleCheck.js
@@ -1,3 +1,15 @@
+// Shared by every page that loads this script (via a plain <script> tag,
+// not a module import) — reads the logged-in admin's roles out of
+// sessionStorage, failing closed to no roles rather than throwing past
+// whatever access check called this.
+function getRoles() {
+  try {
+    return JSON.parse(sessionStorage.getItem('roles') || '[]');
+  } catch (e) {
+    return [];
+  }
+}
+
 function checkRoleAccess(allowedRoles) {
   // First check if user is logged in
   const userToken =
@@ -7,12 +19,7 @@ function checkRoleAccess(allowedRoles) {
     return;
   }
 
-  let roles;
-  try {
-    roles = JSON.parse(sessionStorage.getItem('roles') || '[]');
-  } catch (e) {
-    roles = []; // malformed session data must fail closed, not throw past the check
-  }
+  const roles = getRoles();
   const currentPage = window.location.pathname.split('/').pop();
 
   const hasAccess = roles.some((role) => allowedRoles.includes(role));
@@ -69,12 +76,7 @@ function logout() {
 }
 
 function getHomePageForRole() {
-  let roles;
-  try {
-    roles = JSON.parse(sessionStorage.getItem('roles') || '[]');
-  } catch (e) {
-    roles = [];
-  }
+  const roles = getRoles();
 
   // Check if user has any valid roles
   const validRoles = [


### PR DESCRIPTION
## Summary
- New admin dashboard (`admin/ticket/tickets.html` + `tickets.js`) for the chat-based support ticketing system: ticket list with polling refresh, live chat drawer over SSE, status updates, department-scoped filtering.
- Department RBAC: `TICKET_ROLE_SERVICE_MAP` mirrors the backend's role→service mapping so each department admin (maintenanceAdmin, housekeepingAdmin, foodAdmin, travelAdmin, officeAdmin) only sees their own tickets; superAdmin sees everything. Server-side enforcement lives in the backend PR — this is UX-level filtering plus the shared "Support Tickets" home button wired into `adminhome.html` for the relevant roles.
- SSE is consumed via a hand-rolled fetch + ReadableStream reader (vanilla JS admin panel can't use browser `EventSource` since it can't set the Authorization header), with reconnect/watchdog handling for dropped connections.

## Key pieces
- `admin/ticket/tickets.js` — list/detail/stream logic, scroll-position-preserving message rendering, stale-response race protection when switching tickets quickly.
- `style/js/roleCheck.js` — shared `getRoles()` helper (previously each page parsed `sessionStorage` roles independently).
- `style/js/htmlEscape.js` — shared `escapeHtml()` (previously duplicated across 3 files).
- `admin/adminhome.html` — added "Support Tickets" button for relevant department roles.

## Testing
- Manual end-to-end pass via local static server + local backend: opening tickets, live message delivery, status changes reflecting instantly on the app side, role-based filtering per department, reconnect after simulated drops.
- Went through a full `/code-review` pass (xhigh effort, 15 verified findings) — all fixed. Followed by a `/simplify` cleanup pass — all findings applied or explicitly skipped as false positives.

## Test plan
- [ ] Confirm each department admin role is actually assigned to the right prod accounts (ops task, not code)
- [ ] Smoke test in a real browser against the deployed backend (local testing used a temporary local API override, reverted before commit)