### PR TITLE
ci: read code-review model/effort from repo Variables

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,4 +52,12 @@ jobs:
 
           # --allowedTools must include the inline-comment tool, or the review
           # falls back to a single summary comment with no line-anchored comments.
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)" --model claude-opus-4-8 --effort max'
+          #
+          # Model and effort are read from repository Variables so they can be
+          # changed from the GitHub UI (Settings > Secrets and variables >
+          # Actions > Variables) without editing this file. If a variable is
+          # unset, the fallback after `||` is used, preserving current behavior.
+          claude_args: >-
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-8' }}
+            --effort ${{ vars.CLAUDE_EFFORT || 'max' }}


### PR DESCRIPTION
Move the hardcoded --model/--effort in the Claude code-review workflow to GitHub repository Variables (CLAUDE_MODEL, CLAUDE_EFFORT) with the current values as fallback defaults, so they can be changed from the GitHub Settings UI without editing this file. Behavior is unchanged until a variable is set.