### PR TITLE
Travel list: adhyayan session + round-trip

### DIFF
--- a/admin/card/createCard.html
+++ b/admin/card/createCard.html
@@ -191,6 +191,7 @@
                         <option value="Friend">Friend</option>
                         <option value="Driver">Driver</option>
                         <option value="VIP">VIP</option>
+                        <option value="Vendor">Vendor</option>
                       </select>
                     </div>
                   </div>

--- a/admin/card/updateCard.html
+++ b/admin/card/updateCard.html
@@ -194,6 +194,7 @@
     <option value="Friend">Friend</option>
     <option value="Driver">Driver</option>
                         <option value="VIP">VIP</option>
+                        <option value="Vendor">Vendor</option>
                       </select>
 </div>
  -->

--- a/admin/travel/fetchUpcomingBookings.html
+++ b/admin/travel/fetchUpcomingBookings.html
@@ -158,7 +158,8 @@
                   <th data-key="bus_name">Bus Name</th>
                   <th data-key="coordinator_bookingid">Coordinator?</th>
                   <th data-key="arrival_time">Train/Flight Time</th>
-                  <th data-key="leaving_post_adhyayan">Attending Adhyayan</th>
+                  <th data-key="adhyayan">Adhyayan (Session)</th>
+                  <th data-key="trip_group_id">Round Trip</th>
                   <th data-key="status">Booking Status</th>
                   <th data-key="action">Action</th>
                   <th data-key="comments">Mumukshu Comments</th>
@@ -332,15 +333,6 @@
             <option value="">Select Type</option>
             <option value="Regular">Regular</option>
             <option value="Full Car">Full Car</option>
-          </select>
-        </div>
-
-        <div class="form-group">
-          <label>Attending Adhyayan</label>
-          <select id="txnLeavingPostAdhyayan" class="form-control">
-            <option value="">Select</option>
-            <option value="1">Yes</option>
-            <option value="0">No</option>
           </select>
         </div>
 

--- a/admin/travel/fetchUpcomingBookings.html
+++ b/admin/travel/fetchUpcomingBookings.html
@@ -158,8 +158,8 @@
                   <th data-key="bus_name">Bus Name</th>
                   <th data-key="coordinator_bookingid">Coordinator?</th>
                   <th data-key="arrival_time">Train/Flight Time</th>
-                  <th data-key="adhyayan">Adhyayan (Session)</th>
-                  <th data-key="trip_group_id">Round Trip</th>
+                  <th data-key="adhyayan_label">Adhyayan (Session)</th>
+                  <th data-key="trip_group_label">Round Trip</th>
                   <th data-key="status">Booking Status</th>
                   <th data-key="action">Action</th>
                   <th data-key="comments">Mumukshu Comments</th>

--- a/admin/travel/fetchUpcomingBookings.js
+++ b/admin/travel/fetchUpcomingBookings.js
@@ -197,8 +197,8 @@ document.addEventListener('DOMContentLoaded', async function () {
         travelReport.forEach((b) => {
           b.adhyayan_label = b.adhyayan
             ? `${b.adhyayan.name} (${formatDate(b.adhyayan.start_date)}–${formatDate(b.adhyayan.end_date)})`
-            : '—';
-          b.trip_group_label = b.trip_group_id ? 'Round trip' : '—';
+            : '-';
+          b.trip_group_label = b.trip_group_id ? 'Round trip' : '-';
         });
 
         setupDownloadButton();
@@ -209,7 +209,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         const normalize = str =>
           (str || "")
             .toLowerCase()
-            .replace(/[–—]/g, '-') // normalize dash variants
+            .replace(/[\u2013\u2014]/g, '-') // normalize dash variants
             .trim()
             .replace(/\s+/g, ' ');
 
@@ -315,13 +315,13 @@ document.addEventListener('DOMContentLoaded', async function () {
 <td>
   ${b.adhyayan
               ? `${b.adhyayan.name} (${formatDate(b.adhyayan.start_date)}–${formatDate(b.adhyayan.end_date)})`
-              : '—'}
+              : '-'}
 </td>
 
 <td>
   ${b.trip_group_id
               ? '<span class="badge bg-info">Round trip</span>'
-              : '—'}
+              : '-'}
 </td>
 <td>
 

--- a/admin/travel/fetchUpcomingBookings.js
+++ b/admin/travel/fetchUpcomingBookings.js
@@ -191,7 +191,15 @@ document.addEventListener('DOMContentLoaded', async function () {
 
       if (bookingsRes.ok) {
         travelReport = data.data || [];
-        console.log("First booking:", travelReport[0]);
+        // Precompute display-string fields so the Excel export (which reads the raw
+        // field named by each column's data-key) mirrors what the table renders,
+        // instead of exporting "[object Object]" for adhyayan or the raw trip id.
+        travelReport.forEach((b) => {
+          b.adhyayan_label = b.adhyayan
+            ? `${b.adhyayan.name} (${formatDate(b.adhyayan.start_date)}–${formatDate(b.adhyayan.end_date)})`
+            : '—';
+          b.trip_group_label = b.trip_group_id ? 'Round trip' : '—';
+        });
 
         setupDownloadButton();
 

--- a/admin/travel/fetchUpcomingBookings.js
+++ b/admin/travel/fetchUpcomingBookings.js
@@ -305,9 +305,15 @@ document.addEventListener('DOMContentLoaded', async function () {
 </td>
 
 <td>
-  ${b.leaving_post_adhyayan == 1
-              ? 'Yes'
-              : 'No'}
+  ${b.adhyayan
+              ? `${b.adhyayan.name} (${formatDate(b.adhyayan.start_date)}–${formatDate(b.adhyayan.end_date)})`
+              : '—'}
+</td>
+
+<td>
+  ${b.trip_group_id
+              ? '<span class="badge bg-info">Round trip</span>'
+              : '—'}
 </td>
 <td>
 
@@ -447,10 +453,6 @@ async function openTransactionEditModal(bookingId) {
   document.getElementById('txnType').value = booking.type ?? '';
   document.getElementById('txnTravelDate').value = booking.date ? booking.date.split('T')[0] : '';
 
-  document.getElementById('txnLeavingPostAdhyayan').value =
-    booking.leaving_post_adhyayan != null
-      ? String(booking.leaving_post_adhyayan)
-      : '';
   await loadAvailableBusRoutes(
     booking
   );
@@ -558,7 +560,6 @@ document.getElementById('transactionForm').addEventListener('submit', async (eve
     drop_point: document.getElementById('txnDrop').value,
     type: document.getElementById('txnType').value,
     date: document.getElementById('txnTravelDate').value,
-    leaving_post_adhyayan: document.getElementById('txnLeavingPostAdhyayan').value,
     bus_group_id: document.getElementById('txnBusGroup').value,
     is_coordinator: document.getElementById('txnIsCoordinator').value,
   };


### PR DESCRIPTION
## Travel list: adhyayan session + round-trip

Staff dashboard changes for the travel feature (pairs with the aashray-backend PR).

### What's included
- Replaced the old self-reported **"Attending Adhyayan"** Yes/No column with the real **"Adhyayan (Session)"** — shows the traveler's registered study session (name + dates) derived by the backend, or `—`.
- Added a **"Round Trip"** column (badge when the booking's legs are linked).
- Removed the deprecated `leaving_post_adhyayan` edit control from the booking edit modal.

Requires the aashray-backend PR (returns `adhyayan` + `trip_group_id` on the travel list). Header/row column counts kept in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
