### PR TITLE
ci: allow Claude review to update its progress comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -58,6 +58,6 @@ jobs:
           # Actions > Variables) without editing this file. If a variable is
           # unset, the fallback after `||` is used, preserving current behavior.
           claude_args: >-
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
             --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-8' }}
             --effort ${{ vars.CLAUDE_EFFORT || 'max' }}


### PR DESCRIPTION
## What
Add `mcp__github_comment__update_claude_comment` to the Claude review `--allowedTools`.

## Why
`track_progress: true` makes the review update a progress comment via that tool, but it was not in the allowlist, so every update was permission-denied. On large PRs the review loops through the denials, exhausts its turns, and fails with `is_error: true` before posting anything (e.g. aashray-backend PR #352). Small PRs finished before it mattered.

## Change
One line — added the tool to the allowlist. No behavior change otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)