### PR TITLE
Fix iOS universal links: correct Apple team ID and add missing paths

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -3,12 +3,16 @@
     "apps": [],
     "details": [
       {
-        "appID": "XQKVYDRXH8.org.vitraagvigyaan.aashray",
+        "appID": "GV7LX9X8B3.org.vitraagvigyaan.aashray",
         "paths": [
           "/adhyayan/*",
           "/utsav/*",
+          "/menu",
+          "/maintenanceRequestList",
           "/pendingPayments",
           "/pendingPayments/*",
+          "/bookings",
+          "/wifi",
           "/"
         ]
       }


### PR DESCRIPTION
## Problem

No iOS universal link worked. Tapping `https://aashray.vitraagvigyaan.org/...` opened Safari instead of the app.

Two separate faults in `.well-known/apple-app-site-association`:

**1. Wrong Apple team ID.** The file declared `XQKVYDRXH8.org.vitraagvigyaan.aashray`. That prefix belongs to "Ritesh Bavisi", an individual account. The App Store app is published by "Shrimad Rajchandra Aatma Tatva Research Centre", team `GV7LX9X8B3`. iOS matches `<teamID>.<bundleID>` exactly, so it rejected the entire association and silently ignored every link.

**2. Four routes were missing from `paths`.** The app registers 9 deeplink routes in `aashray-app/src/config/deeplinks.ts`. The file listed only 5. Missing: `/menu`, `/maintenanceRequestList`, `/bookings`, `/wifi`.

## Change

- `appID` prefix `XQKVYDRXH8` -> `GV7LX9X8B3`
- Added `/menu`, `/maintenanceRequestList`, `/bookings`, `/wifi` to `paths`

`paths` now covers all 9 app routes. `/adhyayan/*` and `/utsav/*` already cover the two feedback sub-routes.

## Ruled out

- File was reachable, HTTP 200, `Content-Type: application/json`, no redirect
- Apple's CDN copy matched the server copy, so this was not a propagation lag
- The `applinks:aashray.vitraagvigyaan.org` entitlement was present in the app build
- Legacy `paths` format is still supported by iOS

## Verification after deploy

1. `curl -s https://aashray.vitraagvigyaan.org/.well-known/apple-app-site-association`
2. `curl -s https://app-site-association.cdn-apple.com/a/v1/aashray.vitraagvigyaan.org` — iOS reads this copy, not the origin. Allow up to ~24h.
3. Once the CDN serves the new file, delete the app and reinstall. iOS fetches the association on install, not on every tap.
4. Tap a link from Notes or Messages. Typing the URL in Safari's address bar never triggers a universal link, even when setup is correct.

No new app build is needed. The binary already carries the right entitlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)